### PR TITLE
Enable flag on exposures to optionally exlcude nil attributes.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -32,8 +32,9 @@ array.
   * `expose SYMBOLS`
     * define a list of fields which will always be exposed
   * `expose SYMBOLS, HASH`
-    * HASH keys include `:if`, `:unless`, `:proc`, `:as`, `:using`, `:format_with`, `:documentation`
+    * HASH keys include `:if`, `:unless`, `:proc`, `:as`, `:using`, `:exlcude_nil`, `:format_with`, `:documentation`
       * `:if` and `:unless` accept hashes (passed during runtime), procs (arguments are object and options), or symbols (checks for presence of the specified key on the options hash)
+      * `:exlcude_nil` defaults to false and when true will not expose the attribute if it is nil.
   * `expose SYMBOL, { :format_with => :formatter }`
     * expose a value, formatting it first
     * `:format_with` can only be applied to one exposure at a time
@@ -56,6 +57,7 @@ module API
       expose :user_name
       expose :text, :documentation => { :type => "string", :desc => "Status update text." }
       expose :ip, :if => { :type => :full }
+      expose :internal_ip, :if => { :type => :full }, :exclude_nil => true
       expose :user_type, user_id, :if => lambda{ |status, options| status.user.public? }
       expose :digest { |status, options| Digest::MD5.hexdigest(satus.txt) }
       expose :replies, :using => API::Status, :as => :replies

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -331,7 +331,7 @@ module Grape
       return nil if object.nil?
       opts = options.merge(runtime_options || {})
       exposures.inject({}) do |output, (attribute, exposure_options)|
-        if (exposure_options.has_key?(:proc) || object.respond_to?(attribute)) && conditions_met?(exposure_options, opts)
+        if (exposure_options.has_key?(:proc) || object.respond_to?(attribute)) && conditions_met?(attribute, exposure_options, opts)
           partial_output = value_for(attribute, opts)
           output[key_for(attribute)] =
             if partial_output.respond_to? :serializable_hash
@@ -389,9 +389,12 @@ module Grape
       end
     end
 
-    def conditions_met?(exposure_options, options)
+    def conditions_met?(attribute, exposure_options, options)
       if_condition = exposure_options[:if]
       unless_condition = exposure_options[:unless]
+      exclude_nil_condition = exposure_options[:exclude_nil]
+
+      return false if exclude_nil_condition && attribute && object.respond_to?(attribute) && object.send(attribute).nil?
 
       case if_condition
         when Hash; if_condition.each_pair{|k,v| return false if options[k.to_sym] != v }

--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -289,6 +289,7 @@ describe Grape::Entity do
       :email => 'bob@example.com',
       :birthday => Time.gm(2012, 2, 27),
       :fantasies => ['Unicorns', 'Double Rainbows', 'Nessy'],
+      :nemesis => nil,
       :friends => [
         mock(:name => "Friend 1", :email => 'friend1@example.com', :fantasies => [], :birthday => Time.gm(2012, 2, 27), :friends => []),
         mock(:name => "Friend 2", :email => 'friend2@example.com', :fantasies => [], :birthday => Time.gm(2012, 2, 27), :friends => [])
@@ -541,54 +542,70 @@ describe Grape::Entity do
       it 'only passes through hash :if exposure if all attributes match' do
         exposure_options = {:if => {:condition1 => true, :condition2 => true}}
 
-        subject.send(:conditions_met?, exposure_options, {}).should be_false
-        subject.send(:conditions_met?, exposure_options, :condition1 => true).should be_false
-        subject.send(:conditions_met?, exposure_options, :condition1 => true, :condition2 => true).should be_true
-        subject.send(:conditions_met?, exposure_options, :condition1 => false, :condition2 => true).should be_false
-        subject.send(:conditions_met?, exposure_options, :condition1 => true, :condition2 => true, :other => true).should be_true
+        subject.send(:conditions_met?, nil, exposure_options, {}).should be_false
+        subject.send(:conditions_met?, nil, exposure_options, :condition1 => true).should be_false
+        subject.send(:conditions_met?, nil, exposure_options, :condition1 => true, :condition2 => true).should be_true
+        subject.send(:conditions_met?, nil, exposure_options, :condition1 => false, :condition2 => true).should be_false
+        subject.send(:conditions_met?, nil, exposure_options, :condition1 => true, :condition2 => true, :other => true).should be_true
       end
 
       it 'looks for presence/truthiness if a symbol is passed' do
         exposure_options = {:if => :condition1}
 
-        subject.send(:conditions_met?, exposure_options, {}).should be_false
-        subject.send(:conditions_met?, exposure_options, {:condition1 => true}).should be_true
-        subject.send(:conditions_met?, exposure_options, {:condition1 => false}).should be_false
-        subject.send(:conditions_met?, exposure_options, {:condition1 => nil}).should be_false
+        subject.send(:conditions_met?, nil, exposure_options, {}).should be_false
+        subject.send(:conditions_met?, nil, exposure_options, {:condition1 => true}).should be_true
+        subject.send(:conditions_met?, nil, exposure_options, {:condition1 => false}).should be_false
+        subject.send(:conditions_met?, nil, exposure_options, {:condition1 => nil}).should be_false
+      end
+
+      it 'looks for presence/truthiness if a symbol is passed' do
+        exposure_options = {:exclude_nil => true}
+
+        subject.send(:conditions_met?, nil, exposure_options, {}).should be_true
+        subject.send(:conditions_met?, :name, exposure_options, {}).should be_true
+        subject.send(:conditions_met?, :nemesis, exposure_options, {}).should be_false
+      end
+
+      it 'looks for presence/truthiness if a symbol is passed' do
+        exposure_options = {:exclude_nil => false}
+
+        subject.send(:conditions_met?, nil, exposure_options, {}).should be_true
+        subject.send(:conditions_met?, :nemesis, exposure_options, {}).should be_true
+        subject.send(:conditions_met?, :name, exposure_options, {}).should be_true
       end
 
       it 'looks for absence/falsiness if a symbol is passed' do
         exposure_options = {:unless => :condition1}
 
-        subject.send(:conditions_met?, exposure_options, {}).should be_true
-        subject.send(:conditions_met?, exposure_options, {:condition1 => true}).should be_false
-        subject.send(:conditions_met?, exposure_options, {:condition1 => false}).should be_true
-        subject.send(:conditions_met?, exposure_options, {:condition1 => nil}).should be_true
+        subject.send(:conditions_met?, nil, exposure_options, {}).should be_true
+        subject.send(:conditions_met?, nil, exposure_options, {:condition1 => true}).should be_false
+        subject.send(:conditions_met?, nil, exposure_options, {:condition1 => false}).should be_true
+        subject.send(:conditions_met?, nil, exposure_options, {:condition1 => nil}).should be_true
       end
 
       it 'only passes through proc :if exposure if it returns truthy value' do
         exposure_options = {:if => lambda{|_,opts| opts[:true]}}
 
-        subject.send(:conditions_met?, exposure_options, :true => false).should be_false
-        subject.send(:conditions_met?, exposure_options, :true => true).should be_true
+        subject.send(:conditions_met?, nil, exposure_options, :true => false).should be_false
+        subject.send(:conditions_met?, nil, exposure_options, :true => true).should be_true
       end
 
       it 'only passes through hash :unless exposure if any attributes do not match' do
         exposure_options = {:unless => {:condition1 => true, :condition2 => true}}
 
-        subject.send(:conditions_met?, exposure_options, {}).should be_true
-        subject.send(:conditions_met?, exposure_options, :condition1 => true).should be_false
-        subject.send(:conditions_met?, exposure_options, :condition1 => true, :condition2 => true).should be_false
-        subject.send(:conditions_met?, exposure_options, :condition1 => false, :condition2 => true).should be_false
-        subject.send(:conditions_met?, exposure_options, :condition1 => true, :condition2 => true, :other => true).should be_false
-        subject.send(:conditions_met?, exposure_options, :condition1 => false, :condition2 => false).should be_true
+        subject.send(:conditions_met?, nil, exposure_options, {}).should be_true
+        subject.send(:conditions_met?, nil, exposure_options, :condition1 => true).should be_false
+        subject.send(:conditions_met?, nil, exposure_options, :condition1 => true, :condition2 => true).should be_false
+        subject.send(:conditions_met?, nil, exposure_options, :condition1 => false, :condition2 => true).should be_false
+        subject.send(:conditions_met?, nil, exposure_options, :condition1 => true, :condition2 => true, :other => true).should be_false
+        subject.send(:conditions_met?, nil, exposure_options, :condition1 => false, :condition2 => false).should be_true
       end
 
       it 'only passes through proc :unless exposure if it returns falsy value' do
         exposure_options = {:unless => lambda{|_,options| options[:true] == true}}
 
-        subject.send(:conditions_met?, exposure_options, :true => false).should be_true
-        subject.send(:conditions_met?, exposure_options, :true => true).should be_false
+        subject.send(:conditions_met?, nil, exposure_options, :true => false).should be_true
+        subject.send(:conditions_met?, nil, exposure_options, :true => true).should be_false
       end
     end
 


### PR DESCRIPTION
For certain APIs I find that it is best for the client if the API hide's attributes that are nil.

Instead of handling this in each serializer (json, plist, xml) I am looking for options to pull control over this into the entity.
