### PR TITLE
update expose with block to not throw syntax error

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -57,7 +57,7 @@ module API
       expose :text, :documentation => { :type => "string", :desc => "Status update text." }
       expose :ip, :if => { :type => :full }
       expose :user_type, user_id, :if => lambda{ |status, options| status.user.public? }
-      expose :digest { |status, options| Digest::MD5.hexdigest(satus.txt) }
+      expose(:digest) { |status, options| Digest::MD5.hexdigest(satus.txt) }
       expose :replies, :using => API::Status, :as => :replies
 
       with_options { :format_with => :iso_timestamp } do


### PR DESCRIPTION
Works with ruby > 1.8.2
