### PR TITLE
support proper merging of nested conditionals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Next Release
 * [#24](https://github.com/intridea/grape-entity/pull/24): Return documentation with `as` param considered - [@drakula2k](https://github.com/drakula2k).
 * [#27](https://github.com/intridea/grape-entity/pull/27): Properly serializing hashes - [@clintonb](https://github.com/clintonb).
 * [#28](https://github.com/intridea/grape-entity/pull/28): Look for method on entity before calling on the object - [@MichaelXavier](https://github.com/MichaelXavier).
+* [#33](https://github.com/intridea/grape-entity/pull/33): Support proper merging of nested conditionals - [@wyattisimo](https://github.com/wyattisimo).
 * Your contribution here.
 
 0.3.0 (2013-03-29)


### PR DESCRIPTION
Currently, nested option blocks containing conditionals like this:

``` ruby
with_options(:if => {:awesome => true}) do
  with_options(:if => {:less_awesome => false}) do
    expose :awesome_thing
  end
end
```

will produce an exposure that reflects only the innermost conditions:

``` ruby
{:if => {:less_awesome => false}}
```

To me, this is unexpected behavior.  I would expect the following exposure from the code above:

``` ruby
{:if => {:awesome => true, :less_awesome => false}}
```

This pull request enables proper merging of nested conditionals.  All `Hash` conditions are merged into a single hash.  `Proc` and `Symbol` conditions are pushed to a special "extras" array.  For evaluation, the hash is added to the extras array and all the conditions are logically ANDed together.
