### PR TITLE
support nested `expose` declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Next Release
 * [#28](https://github.com/intridea/grape-entity/pull/28): Look for method on entity before calling it on the object - [@MichaelXavier](https://github.com/MichaelXavier).
 * [#33](https://github.com/intridea/grape-entity/pull/33): Support proper merging of nested conditionals - [@wyattisimo](https://github.com/wyattisimo).
 * [#43](https://github.com/intridea/grape-entity/pull/43): Call procs in context of entity instance - [@joelvh](https://github.com/joelvh).
+* [#47](https://github.com/intridea/grape-entity/pull/47): Support nested exposures - [@wyattisimo](https://github.com/wyattisimo).
 * Your contribution here.
 
 0.3.0 (2013-03-29)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ module API
       expose :text, documentation: { type: "String", desc: "Status update text." }
       expose :ip, if: { type: :full }
       expose :user_type, :user_id, if: lambda { |status, options| status.user.public? }
+      expose :contact_info do
+        expose :phone
+        expose :address, using: API::Address
+      end
       expose :digest do |status, options|
         Digest::MD5.hexdigest status.txt
       end
@@ -89,9 +93,23 @@ Don't raise an exception and expose as nil, even if the :x cannot be evaluated.
 expose :ip, safe: true
 ```
 
+#### Nested Exposure
+
+Supply a block to define a hash using nested exposures.
+
+```ruby
+expose :contact_info do
+  expose :phone
+  expose :address, using: API::Address
+end
+```
+
 #### Runtime Exposure
 
-Use a block or a `Proc` to evaluate exposure at runtime.
+Use a block or a `Proc` to evaluate exposure at runtime. The supplied block or
+`Proc` will be called with two parameters: the represented object and runtime options.
+
+**NOTE:** A block supplied with no parameters will be evaluated as a nested exposure (see above).
 
 ```ruby
 expose :digest do |status, options|

--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -36,17 +36,6 @@ describe Grape::Entity do
           expect { subject.expose(:name, :email) { true } }.to raise_error ArgumentError
         end
 
-        it 'sets the :proc option in the exposure options' do
-          block = lambda { |_| true }
-          subject.expose :name, using: 'Awesome', &block
-          subject.exposures[:name].should == { proc: block, using: 'Awesome' }
-        end
-
-        it 'references an instance of the entity without any options' do
-          subject.expose(:size) { self }
-          subject.represent(Hash.new).send(:value_for, :size).should be_an_instance_of fresh_class
-        end
-
         it 'references an instance of the entity with :using option' do
           module EntitySpec
             class SomeObject1
@@ -62,7 +51,7 @@ describe Grape::Entity do
             end
           end
 
-          subject.expose(:bogus, using: EntitySpec::BogusEntity) do
+          subject.expose(:bogus, using: EntitySpec::BogusEntity) do |object|
             object.prop1 = "MODIFIED 2"
             object
           end
@@ -73,6 +62,49 @@ describe Grape::Entity do
 
           prop1 = value.send(:value_for, :prop1)
           prop1.should == "MODIFIED 2"
+        end
+
+        context 'with parameters passed to the block' do
+          it 'sets the :proc option in the exposure options' do
+            block = lambda { |_| true }
+            subject.expose :name, using: 'Awesome', &block
+            subject.exposures[:name].should == { proc: block, using: 'Awesome' }
+          end
+
+          it 'references an instance of the entity without any options' do
+            subject.expose(:size) { |_| self }
+            subject.represent(Hash.new).send(:value_for, :size).should be_an_instance_of fresh_class
+          end
+        end
+
+        context 'with no parameters passed to the block' do
+          it 'adds a nested exposure' do
+            subject.expose :awesome do
+              subject.expose :nested do
+                subject.expose :moar_nested, as: 'weee'
+              end
+              subject.expose :another_nested, using: 'Awesome'
+            end
+
+            subject.exposures.should == {
+              awesome: {},
+              awesome__nested: {},
+              awesome__nested__moar_nested: { as: 'weee' },
+              awesome__another_nested: { using: 'Awesome' }
+            }
+          end
+
+          it 'represents the exposure as a hash of its nested exposures' do
+            subject.expose :awesome do
+              subject.expose(:nested) { |_| "value" }
+              subject.expose(:another_nested) { |_| "value" }
+            end
+
+            subject.represent({}).send(:value_for, :awesome).should == {
+              nested: "value",
+              another_nested: "value"
+            }
+          end
         end
       end
 
@@ -293,13 +325,13 @@ describe Grape::Entity do
       end
 
       it 'returns a serialized hash of a single object if serializable: true' do
-        subject.expose(:awesome) { true }
+        subject.expose(:awesome) { |_| true }
         representation = subject.represent(Object.new, serializable: true)
         representation.should == { awesome: true }
       end
 
       it 'returns a serialized array of hashes of multiple objects if serializable: true' do
-        subject.expose(:awesome) { true }
+        subject.expose(:awesome) { |_| true }
         representation = subject.represent(2.times.map { Object.new }, serializable: true)
         representation.should == [{ awesome: true }, { awesome: true }]
       end


### PR DESCRIPTION
See issue #34 

Here's a first attempt at supporting nested exposures.

**Note:**  Previously, any supplied block would be assigned to `options[:proc]` and called with the represented object and the runtime options.  I used that fact as a delineation, so...
1. If the supplied block has parameters, then it will be recognized as a Proc to determine the value of the exposure.
2. If the supplied block has no parameters, then it will be understood that the block contains nested exposures.

This will break any implementations that supply Procs with no parameters.
