### PR TITLE
Specify the class in String in `using` option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,8 @@ tmp
 
 ## PROJECT::SPECIFIC
 .project
+
+
+## RVM
+.ruby-version
+.ruby-gemset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Next Release
 * [#47](https://github.com/intridea/grape-entity/pull/47): Support nested exposures - [@wyattisimo](https://github.com/wyattisimo).
 * Your contribution here.
 
+
+0.4.0 (2014-01-13)
+=================
+* [#46](https://github.com/intridea/grape-entity/issues/46): Enable specifying presenter class in string in full path for `using` option, in order to avoid dependency requirement. - [@larryzhao](https://github.com/larryzhao)
+
 0.3.0 (2013-03-29)
 ==================
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gemspec
 
 group :development, :test do
   gem 'pry'
+  gem 'pry-nav'
   gem 'guard'
   gem 'guard-rspec'
   gem 'guard-bundler'

--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ Don't derive your model classes from `Grape::Entity`, expose them using a presen
 expose :replies, using: API::Status, as: :replies
 ```
 
+#### Specify the Presenter's Class in String.
+
+You could also specify the presenter's class in string in full path in the `using` option, in order to avoid the dependency requirement.
+
+```ruby
+expose :replies, using: 'API::Status', as: :replies
+```
+
 #### Conditional Exposure
 
 Use `:if` or `:unless` to expose fields conditionally.

--- a/lib/grape_entity.rb
+++ b/lib/grape_entity.rb
@@ -1,2 +1,3 @@
+require "active_support/core_ext"
 require "grape_entity/version"
 require "grape_entity/entity"

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -394,6 +394,8 @@ module Grape
       nested_exposures = exposures.select { |a, _| a.to_s =~ /^#{attribute}__/ }
 
       if exposure_options[:using]
+        exposure_options[:using] = exposure_options[:using].constantize if exposure_options[:using].respond_to? :constantize
+
         using_options = options.dup
         using_options.delete(:collection)
         using_options[:root] = nil

--- a/lib/grape_entity/version.rb
+++ b/lib/grape_entity/version.rb
@@ -1,3 +1,3 @@
 module GrapeEntity
-  VERSION = '0.3.0'
+  VERSION = '0.4.0'
 end

--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -635,8 +635,23 @@ describe Grape::Entity do
       end
 
       context 'child representations' do
-        it 'disables root key name for child representations' do
+        it 'corrects find the class constant specified in string' do
+          module EntitySpec
+            class UserEntity < Grape::Entity
+              expose :name, :email
+            end
+          end
 
+          fresh_class.class_eval do
+            expose :friends, using: "EntitySpec::UserEntity"
+          end
+
+          rep = subject.send(:value_for, :friends)
+          rep.should be_kind_of Array
+          rep.reject { |r| r.is_a?(EntitySpec::UserEntity) }.should be_empty
+        end
+
+        it 'disables root key name for child representations' do
           module EntitySpec
             class FriendEntity < Grape::Entity
               root 'friends', 'friend'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,3 +8,4 @@ require 'bundler'
 Bundler.require :default, :test
 
 require 'pry'
+require 'active_support/core_ext'


### PR DESCRIPTION
Now supports specify the class constant in String in `using` option in full path.

Fix for issue: https://github.com/intridea/grape-entity/issues/46
