### PR TITLE
Test that you can reopen nested exposures

### DIFF
--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -195,7 +195,7 @@ module Grape
         value = nested_exposures_hash
 
         if superclass.respond_to? :nested_exposures
-          value = superclass.nested_exposures.merge(value)
+          value = superclass.nested_exposures.deep_merge(value)
         end
 
         value

--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -155,14 +155,14 @@ describe Grape::Entity do
             ClassRoom.represent({}).serializable_hash.should == {
               parents: [
                 {
-                  user: { id: "value", in_first: 'value' },
+                  user: { in_first: 'value' },
                   children: [
                     { user: { in_first: 'value', user_id: "value", display_id: "value" } },
                     { user: { in_first: 'value', user_id: "value", display_id: "value" } }
                   ]
                 },
                 {
-                  user: { id: "value", in_first: 'value' },
+                  user: { in_first: 'value' },
                   children: [
                     { user: { in_first: 'value', user_id: "value", display_id: "value" } },
                     { user: { in_first: 'value', user_id: "value", display_id: "value" } }


### PR DESCRIPTION
Related to https://github.com/intridea/grape-entity/pull/62

The test was actually not right. The exposures inside the :user exposure in the root entity `Person` are getting overwritten in the children.

``` ruby
class Person < Grape::Entity
##This gets overwritten by the exposure in Student. So there is no `:in_first` exposure.
  expose :user do
    expose(:in_first) { |_| 'value' }
  end
end

class Student < Person
  expose :user do
    expose(:user_id) { |_| 'value' }
    expose(:user_display_id, as: :display_id) { |_| 'value' }
  end
end
```

I corrected the test to reproduce the issue.
