### PR TITLE
Detect entity representation on attribute values

### DIFF
--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -924,6 +924,28 @@ describe Grape::Entity do
           rep.all? { |r| r.is_a?(EntitySpec::UserEntity) }.should be_true
         end
       end
+
+      context "object from DSL class" do
+        it "should use the DSL class's entity" do
+          module EntitySpec
+            class ObjectWithDSL
+              include Grape::Entity::DSL
+              entity do
+                expose(:foo) { "FOO" }
+              end
+
+              def as_json
+                { bar: "BAR" }
+              end
+              alias_method :serializable_hash, :as_json
+            end
+          end
+
+          fresh_class.expose(:object_with_dsl)
+          model.should_receive(:object_with_dsl).and_return(EntitySpec::ObjectWithDSL.new)
+          subject.send(:value_for, :object_with_dsl).should be_kind_of(EntitySpec::ObjectWithDSL::Entity)
+        end
+      end
     end
 
     describe '#documentation' do


### PR DESCRIPTION
This is something I've run into a number of times and (I think) this solves the issue. I'd like feedback in case there are dangers of which I'm not aware here. The problem is this:

```
class User < ActiveRecord::Base
  include Grape::Entity::DSL

  entity do
    expose(:name){ "Bob" }
  end
end

class Project < ActiveRecord::Base
  include Grape::Entity::DSL
  def user; User.new; end

  entity do
    expose :user
  end
end
```

With the above code, what I would **expect** is the JSON representation to look like:

``` json
{
  "user": {
    "name": "Bob"
  }
}
```

Instead the native JSON representation for the object is coming through. This pull request alters the default behavior when no `:using` or `:proc` or block are specified on an exposure and tries to detect an entity for it, first by `value.entity` then by `value.class.entity_class.represent(value)`.

I believe this is making the behavior more what someone would expect. Any thoughts @dblock or others?
