### PR TITLE
Fix undefining merge method for nil:class issue

### DIFF
--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -391,6 +391,7 @@ module Grape
     #   etc.
     def serializable_hash(runtime_options = {})
       return nil if object.nil?
+      options = {} if options.nil?
       opts = options.merge(runtime_options || {})
       valid_exposures.inject({}) do |output, (attribute, exposure_options)|
         if conditions_met?(exposure_options, opts)


### PR DESCRIPTION
I'm having troubles when the options variable is not declared. 
