### PR TITLE
Match Grape's build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache: bundler
 
 rvm:
   - ruby-head
-  - 2.1.1
+  - 2.1.2
   - 2.1.0
   - 2.0.0
   - 1.9.3


### PR DESCRIPTION
Would be great to know Ruby 2.1.2 is supported.
