### PR TITLE
Respect nested conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Next Release
 ============
 
 * Your contribution here.
+* [#98](https://github.com/intridea/grape-entity/pull/98): Add nested conditionals - [@zbelzer](https://github.com/zbelzer).
 * [#91](https://github.com/intridea/grape-entity/pull/91): Fix OpenStruct serializing - [@etehtsea](https://github.com/etehtsea).
 
 0.4.4 (2014-08-17)

--- a/README.md
+++ b/README.md
@@ -117,6 +117,16 @@ expose :contact_info do
 end
 ```
 
+You can also conditionally expose attributes in nested exposures:
+```ruby
+expose :contact_info do
+  expose :phone
+  expose :address, using: API::Address
+  expose :email, if: lambda { |instance, options| options[:type] == :full }
+end
+```
+
+
 #### Collection Exposure
 
 Use `root(plural, singular = nil)` to expose an object or a collection of objects with a root key.

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -535,10 +535,14 @@ module Grape
         end
 
       elsif nested_exposures.any?
-        Hash[nested_exposures.map do |nested_attribute, _|
-          [self.class.key_for(nested_attribute), value_for(nested_attribute, options)]
-        end]
+        nested_attributes =
+          nested_exposures.map do |nested_attribute, nested_exposure_options|
+            if conditions_met?(nested_exposure_options, options)
+              [self.class.key_for(nested_attribute), value_for(nested_attribute, options)]
+            end
+          end
 
+        Hash[nested_attributes.compact]
       else
         delegate_attribute(attribute)
       end

--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -111,6 +111,15 @@ describe Grape::Entity do
             )
           end
 
+          it 'does not represent nested exposures whose conditions are not met' do
+            subject.expose :awesome do
+              subject.expose(:condition_met, if: lambda { |_, _| true }) { |_| 'value' }
+              subject.expose(:condition_not_met, if: lambda { |_, _| false }) { |_| 'value' }
+            end
+
+            expect(subject.represent({}).send(:value_for, :awesome)).to eq(condition_met: 'value')
+          end
+
           it 'does not represent attributes, declared inside nested exposure, outside of it' do
             subject.expose :awesome do
               subject.expose(:nested) { |_| 'value' }


### PR DESCRIPTION
I was surprised this didn't work, but seeing that it was just a hash, I kind of get why not. Seemed simple enough to add this behavior as the nested exposures carry this info around.

```
$ rake
Running RuboCop...
Inspecting 9 files
.........

9 files inspected, no offenses detected
.....................................................................................................

Finished in 0.02879 seconds (files took 0.82928 seconds to load)
```
