### PR TITLE
support dynamic attributes & merging collection values

### DIFF
--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -498,7 +498,7 @@ module Grape
 
     # All supported options.
     OPTIONS = [
-      :rewrite, :as, :if, :unless, :using, :with, :proc, :documentation, :format_with, :safe, :attr_path, :if_extras, :unless_extras
+      :rewrite, :as, :if, :unless, :using, :with, :proc, :documentation, :format_with, :safe, :attr_path, :if_extras, :unless_extras, :combine
     ].to_set.freeze
 
     # Merges the given options with current block options.

--- a/lib/grape_entity/exposure/base.rb
+++ b/lib/grape_entity/exposure/base.rb
@@ -64,7 +64,11 @@ module Grape
           if partial_output.respond_to?(:serializable_hash)
             partial_output.serializable_hash(options)
           elsif partial_output.is_a?(Array) && partial_output.all? { |o| o.respond_to?(:serializable_hash) }
-            partial_output.map(&:serializable_hash)
+            if @options[:combine] == :merge
+              partial_output.reduce({}) { |memo, output| memo.merge(output.serializable_hash) }
+            else
+              partial_output.map(&:serializable_hash)
+            end
           elsif partial_output.is_a?(Hash)
             partial_output.each do |key, value|
               partial_output[key] = value.serializable_hash if value.respond_to?(:serializable_hash)

--- a/lib/grape_entity/exposure/nesting_exposure.rb
+++ b/lib/grape_entity/exposure/nesting_exposure.rb
@@ -57,7 +57,15 @@ module Grape
           normalized_exposures(entity, new_options).each_with_object({}) do |exposure, output|
             exposure.with_attr_path(entity, new_options) do
               result = exposure.serializable_value(entity, new_options)
-              output[exposure.key] = result
+
+              exposure_key = exposure.key.to_s
+              actual_key = if exposure_key.start_with?('__')
+                             entity.delegate_attribute(exposure_key[2..-1].to_sym)
+                           else
+                             exposure.key
+                           end
+
+              output[actual_key] = result
             end
           end
         end


### PR DESCRIPTION
This is the start of my proposed solution to the problem I outlined on the mailing list [here](https://groups.google.com/forum/#!topic/ruby-grape/cWnj8tZnOMw). It doesn't add general purpose dynamic attribute, it just allows you to evaluate the 'parent' attribute of a nested attribute structure dynamically through a hacky naming convention (`__` prefix on the attribute name). I would have rather used a block to evaluate the value of the dynamic attribute, but I wasn't sure what all of the the implications of creating a `NestingExposure` were.