### PR TITLE
Fix class name in docs

### DIFF
--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -336,7 +336,7 @@ module Grape
     #
     #       class Users < Grape::Entity
     #         present_collection true
-    #         expose :items, as: 'users', using: API::Entities::Users
+    #         expose :items, as: 'users', using: API::Entities::User
     #         expose :version, documentation: { type: 'string',
     #                                           desc: 'actual api version',
     #                                           required: true }


### PR DESCRIPTION
A small typo, but an important one. It definitely confused me for a moment.