### PR TITLE
Fix: exposure safe attributes as nil

### DIFF
--- a/lib/grape_entity/exposure/base.rb
+++ b/lib/grape_entity/exposure/base.rb
@@ -75,7 +75,7 @@ module Grape
         end
 
         def valid_value(entity, options)
-          valid?(entity) && value(entity, options)
+          value(entity, options) if valid?(entity)
         end
 
         def should_return_key?(options)

--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -1054,13 +1054,20 @@ describe Grape::Entity do
           expect(fresh_class.new(some_class.new).serializable_hash).to eq(name: true)
         end
 
-        it "does expose attributes that don't exist on the object as nil" do
+        it "does expose attributes that don't exist on the object" do
           fresh_class.expose :email, :nonexistent_attribute, :name, safe: true
 
           res = fresh_class.new(model).serializable_hash
           expect(res).to have_key :email
           expect(res).to have_key :nonexistent_attribute
           expect(res).to have_key :name
+        end
+
+        it "does expose attributes that don't exist on the object as nil" do
+          fresh_class.expose :email, :nonexistent_attribute, :name, safe: true
+
+          res = fresh_class.new(model).serializable_hash
+          expect(res[:nonexistent_attribute]).to eq(nil)
         end
 
         it 'does expose attributes marked as safe if model is a hash object' do


### PR DESCRIPTION
This is a regression only in WIP `0.5.0` version: refactored code emits `false`, not `nil` :(
Spec added.