### PR TITLE
hashes and delegation failing spec

### DIFF
--- a/lib/grape_entity/delegator/hash_object.rb
+++ b/lib/grape_entity/delegator/hash_object.rb
@@ -5,6 +5,10 @@ module Grape
         def delegate(attribute)
           object[attribute]
         end
+
+        def delegatable?(attribute)
+          object.key? attribute
+        end
       end
     end
   end


### PR DESCRIPTION
Many specs fail with `missing attribute ...` exception.

But there are some reasons that it's right. No value for some key -> cannot expose such attribute. Otherwise `nil` value is indistinguishable from no-key case. It also makes unclear should we call formatter on this value or not if one is specified.

Fixing it will obviously be a  breaking change since all these specs should be rewritten.

Upgrade path will be to use `safe` option.