### PR TITLE
fix(options): Preserve Only and Except Options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 * [#151](https://github.com/ruby-grape/grape-entity/pull/151): Fix: `@documentation` memoization: [#153](https://github.com/ruby-grape/grape-entity/issues/153) - [@marshall-lee](https://github.com/marshall-lee).
 * [#151](https://github.com/ruby-grape/grape-entity/pull/151): Fix: serializing of deeply nested presenter exposures: [#155](https://github.com/ruby-grape/grape-entity/issues/155) - [@marshall-lee](https://github.com/marshall-lee).
 * [#151](https://github.com/ruby-grape/grape-entity/pull/151): Fix: deep projections (`:only`, `:except`) were unaware of nesting: [#156](https://github.com/ruby-grape/grape-entity/issues/156) - [@marshall-lee](https://github.com/marshall-lee).
+* [#182](https://github.com/ruby-grape/grape-entity/pull/182): Fix: preserving options for `:only` and `:except` when merging new options into existing object: [#181](https://github.com/ruby-grape/grape-entity/issues/181) - [@Linell](https://github.com/Linell).
+* Your contribution here.
 
 0.4.8 (2015-08-10)
 ==================

--- a/lib/grape_entity/options.rb
+++ b/lib/grape_entity/options.rb
@@ -28,6 +28,13 @@ module Grape
                    else
                      @opts_hash.merge(new_opts)
                    end
+
+          only = opts_hash[:only]
+          merged[:only] = only unless only.nil? || only.empty?
+
+          except = opts_hash[:except]
+          merged[:except] = except unless only.nil? || only.empty?
+
           Options.new(merged)
         end
       end


### PR DESCRIPTION
Don't override `options[:only]` and `options[:except]` when merging in new options.

Resolves #181 
