### PR TITLE
Allow to associate meta data with entities

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,7 +12,7 @@ Metrics/AbcSize:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 202
+  Max: 212
 
 # Offense count: 3
 Metrics/CyclomaticComplexity:

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -112,13 +112,16 @@ module Grape
       end
 
       attr_writer :formatters
+      attr_writer :meta
     end
 
     @formatters = {}
+    @meta = {}
 
     def self.inherited(subclass)
       subclass.root_exposure = root_exposure.dup
       subclass.formatters = formatters.dup
+      subclass.meta = meta.dup
     end
 
     # This method is the primary means by which you will declare what attributes
@@ -271,6 +274,26 @@ module Grape
     def self.format_with(name, &block)
       fail ArgumentError, 'You must pass a block for formatters' unless block_given?
       formatters[name.to_sym] = block
+    end
+
+    # This allows you to declare meta data on the entity level, which can be useful for
+    # automated documentation.
+    #
+    # @param pairs [Hash] the name-value pairs to associate
+    #
+    # @example Meta declaration
+    #
+    #   module API
+    #     module Entities
+    #       class User < Grape::Entity
+    #         meta description: "My user entity"
+    #       end
+    #     end
+    #   end
+    #
+    def self.meta(pairs = nil)
+      @meta.update(pairs) if pairs.is_a?(Hash)
+      @meta
     end
 
     # This allows you to set a root element name for your representation.
@@ -447,6 +470,10 @@ module Grape
 
     def formatters
       self.class.formatters
+    end
+
+    def meta
+      self.class.meta
     end
 
     # The serializable hash is the Entity's primary output. It is the transformed

--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -274,6 +274,21 @@ describe Grape::Entity do
         end
       end
 
+      context 'declare meta' do
+        it 'sets meta data' do
+          subject.meta description: 'My favourite entity'
+
+          expect(subject.meta).to include(description: 'My favourite entity')
+        end
+
+        it 'inherits meta from ancestors' do
+          subject.meta final: true
+          child_class = Class.new(subject)
+
+          expect(child_class.meta).to eq subject.meta
+        end
+      end
+
       context 'register formatters' do
         let(:date_formatter) { ->(date) { date.strftime('%m/%d/%Y') } }
 


### PR DESCRIPTION
It would be really handy to be able to associate custom meta data with entities to generate automated documentation.