### PR TITLE
Fix: reset `@using_class` memoization on `.setup`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ============
 
 * Your contribution here.
+* [#202](https://github.com/ruby-grape/grape-entity/pull/202): Fix: Reset `@using_class` memoization on `.setup` - [@rngtng](https://github.com/rngtng).
 
 0.5.0 (2015-12-07)
 ==================

--- a/lib/grape_entity/exposure/represent_exposure.rb
+++ b/lib/grape_entity/exposure/represent_exposure.rb
@@ -5,6 +5,7 @@ module Grape
         attr_reader :using_class_name, :subexposure
 
         def setup(using_class_name, subexposure)
+          @using_class = nil
           @using_class_name = using_class_name
           @subexposure = subexposure
         end

--- a/spec/grape_entity/exposure/represent_exposure_spec.rb
+++ b/spec/grape_entity/exposure/represent_exposure_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe Grape::Entity::Exposure::RepresentExposure do
+  subject(:exposure) { described_class.new(:foo, {}, {}, double, double) }
+
+  describe '#setup' do
+    subject { exposure.setup(using_class_name, subexposure) }
+
+    let(:using_class_name) { double(:using_class_name) }
+    let(:subexposure)      { double(:subexposure) }
+
+    it 'sets using_class_name' do
+      expect { subject }.to change { exposure.using_class_name }.to(using_class_name)
+    end
+
+    it 'sets subexposure' do
+      expect { subject }.to change { exposure.subexposure }.to(subexposure)
+    end
+
+    context 'when using_class is set' do
+      before do
+        exposure.using_class
+      end
+
+      it 'resets using_class' do
+        expect { subject }.to change { exposure.using_class }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes a tiny bug where calling `.setup` on `RepresentExposure` wouldn't 'reset' `@using_class`. As of this, it was possible that `@using_class` and `@using_class_name` were referencing different classes.

