### PR TITLE
Fix: return `self` instead of `nil` if no attribute was deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 * Your contribution here.
 * [#202](https://github.com/ruby-grape/grape-entity/pull/202): Fix: Reset `@using_class` memoization on `.setup` - [@rngtng](https://github.com/rngtng).
+* [#203](https://github.com/ruby-grape/grape-entity/pull/203): Grape::Entity::Exposure::NestingExposure::NestedExposures.delete_if always returns exposures. - [@rngtng](https://github.com/rngtng).
 
 0.5.0 (2015-12-07)
 ==================

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,8 @@
+Upgrading Grape Entity
+===============
+
+### Upgrading to >= 0.5.1
+
+* `Grape::Entity::Exposure::NestingExposure::NestedExposures.delete_if` always
+returns exposures, regardless of delete result (used to be
+`nil` in negative case), see [#203](https://github.com/ruby-grape/grape-entity/pull/203).

--- a/lib/grape_entity/exposure/nesting_exposure/nested_exposures.rb
+++ b/lib/grape_entity/exposure/nesting_exposure/nested_exposures.rb
@@ -21,6 +21,7 @@ module Grape
           def delete_by(*attributes)
             reset_memoization!
             @exposures.reject! { |e| attributes.include? e.attribute }
+            @exposures
           end
 
           def clear

--- a/spec/grape_entity/exposure/nesting_exposure/nested_exposures_spec.rb
+++ b/spec/grape_entity/exposure/nesting_exposure/nested_exposures_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Grape::Entity::Exposure::NestingExposure::NestedExposures do
-  subject { described_class.new([]) }
+  subject(:nested_exposures) { described_class.new([]) }
 
   describe '#deep_complex_nesting?' do
     it 'is reset when additional exposure is added' do
@@ -29,6 +29,28 @@ describe Grape::Entity::Exposure::NestingExposure::NestedExposures do
       expect(subject.instance_variable_get(:@deep_complex_nesting)).to_not be_nil
       subject.clear
       expect(subject.instance_variable_get(:@deep_complex_nesting)).to be_nil
+    end
+  end
+
+  describe '.delete_by' do
+    subject { nested_exposures.delete_by(*attributes) }
+
+    let(:attributes) { [:id] }
+
+    before do
+      nested_exposures << Grape::Entity::Exposure.new(:id, {})
+    end
+
+    it 'deletes matching exposure' do
+      is_expected.to eq []
+    end
+
+    context "when given attribute doesn't exists" do
+      let(:attributes) { [:foo] }
+
+      it 'deletes matching exposure' do
+        is_expected.to eq(nested_exposures)
+      end
     end
   end
 end


### PR DESCRIPTION
If a given attribute of `delete_if` couldn't be found, `nil` was returned [as described in ruby spec](http://ruby-doc.org/core-2.2.4/Array.html#method-i-reject-21). Although, I expected `@exposures`  to be return, to maintain consistency with the cases when sth. is found.