### PR TITLE
Add option :merge to expose. Allow to merge fields into nested hashes and into the root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 * Your contribution here.
 
+* [#204](https://github.com/ruby-grape/grape-entity/pull/204): Added ability to merge fields into hashes/root (`:merge` option for `.expose`): [#138](https://github.com/ruby-grape/grape-entity/issues/138) - [@avyy](https://github.com/avyy).
+
 0.5.0 (2015-12-07)
 ==================
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ module API
       expose :text, documentation: { type: "String", desc: "Status update text." }
       expose :ip, if: { type: :full }
       expose :user_type, :user_id, if: lambda { |status, options| status.user.public? }
+      expose :location, merge: true
       expose :contact_info do
         expose :phone
-        expose :address, using: API::Entities::Address
+        expose :address, merge: true, using: API::Entities::Address
       end
       expose :digest do |status, options|
         Digest::MD5.hexdigest status.txt
@@ -151,6 +152,40 @@ As example:
  expose :collection_name, using: API::Entities::Items
 
 
+```
+
+#### Merge Fields
+
+Use `:merge` option to merge fields into the hash or into the root:
+
+```ruby
+expose :contact_info do
+  expose :phone
+  expose :address, merge: true, using: API::Entities::Address
+end
+
+expose :status, merge: true
+```
+
+This will return something like:
+
+```ruby
+{ contact_info: { phone: "88002000700", city: 'City 17', address_line: 'Block C' }, text: 'HL3', likes: 19 }
+```
+
+It also works with collections:
+
+```ruby
+expose :profiles do
+  expose :users, merge: true, using: API::Entities::User
+  expose :admins, merge: true, using: API::Entities::Admin
+end
+```
+
+Provide lambda to solve collisions:
+
+```ruby
+expose :status, merge: ->(key, old_val, new_val) { old_val + new_val if old_val && new_val }
 ```
 
 #### Runtime Exposure

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -146,6 +146,7 @@ module Grape
     #   block to the expose call to achieve the same effect.
     # @option options :documentation Define documenation for an exposed
     #   field, typically the value is a hash with two fields, type and desc.
+    # @option options :merge This option allows you to merge an exposed field to the root
     def self.expose(*args, &block)
       options = merge_options(args.last.is_a?(Hash) ? args.pop : {})
 
@@ -498,7 +499,7 @@ module Grape
 
     # All supported options.
     OPTIONS = [
-      :rewrite, :as, :if, :unless, :using, :with, :proc, :documentation, :format_with, :safe, :attr_path, :if_extras, :unless_extras
+      :rewrite, :as, :if, :unless, :using, :with, :proc, :documentation, :format_with, :safe, :attr_path, :if_extras, :unless_extras, :merge
     ].to_set.freeze
 
     # Merges the given options with current block options.

--- a/lib/grape_entity/exposure/base.rb
+++ b/lib/grape_entity/exposure/base.rb
@@ -2,7 +2,7 @@ module Grape
   class Entity
     module Exposure
       class Base
-        attr_reader :attribute, :key, :is_safe, :documentation, :conditions
+        attr_reader :attribute, :key, :is_safe, :documentation, :conditions, :for_merge
 
         def self.new(attribute, options, conditions, *args, &block)
           super(attribute, options, conditions).tap { |e| e.setup(*args, &block) }
@@ -13,6 +13,7 @@ module Grape
           @options = options
           @key = (options[:as] || attribute).try(:to_sym)
           @is_safe = options[:safe]
+          @for_merge = options[:merge]
           @attr_path_proc = options[:attr_path]
           @documentation = options[:documentation]
           @conditions = conditions

--- a/lib/grape_entity/exposure/nesting_exposure.rb
+++ b/lib/grape_entity/exposure/nesting_exposure.rb
@@ -30,11 +30,12 @@ module Grape
 
         def value(entity, options)
           new_options = nesting_options_for(options)
+          output = OutputBuilder.new
 
-          normalized_exposures(entity, new_options).each_with_object({}) do |exposure, output|
+          normalized_exposures(entity, new_options).each_with_object(output) do |exposure, out|
             exposure.with_attr_path(entity, new_options) do
               result = exposure.value(entity, new_options)
-              output[exposure.key] = result
+              out.add(exposure, result)
             end
           end
         end
@@ -53,11 +54,12 @@ module Grape
 
         def serializable_value(entity, options)
           new_options = nesting_options_for(options)
+          output = OutputBuilder.new
 
-          normalized_exposures(entity, new_options).each_with_object({}) do |exposure, output|
+          normalized_exposures(entity, new_options).each_with_object(output) do |exposure, out|
             exposure.with_attr_path(entity, new_options) do
               result = exposure.serializable_value(entity, new_options)
-              output[exposure.key] = result
+              out.add(exposure, result)
             end
           end
         end
@@ -126,3 +128,4 @@ module Grape
 end
 
 require 'grape_entity/exposure/nesting_exposure/nested_exposures'
+require 'grape_entity/exposure/nesting_exposure/output_builder'

--- a/lib/grape_entity/exposure/nesting_exposure/output_builder.rb
+++ b/lib/grape_entity/exposure/nesting_exposure/output_builder.rb
@@ -1,0 +1,58 @@
+module Grape
+  class Entity
+    module Exposure
+      class NestingExposure
+        class OutputBuilder < SimpleDelegator
+          def initialize
+            @output_hash = {}
+            @output_collection = []
+          end
+
+          def add(exposure, result)
+            # Save a result array in collections' array if it should be merged
+            if result.is_a?(Array) && exposure.for_merge
+              @output_collection << result
+            else
+
+              # If we have an array which should not be merged - save it with a key as a hash
+              # If we have hash which should be merged - save it without a key (merge)
+              if exposure.for_merge
+                @output_hash.merge! result, &merge_strategy(exposure.for_merge)
+              else
+                @output_hash[exposure.key] = result
+              end
+
+            end
+          end
+
+          def __getobj__
+            output
+          end
+
+          private
+
+          # If output_collection contains at least one element we have to represent the output as a collection
+          def output
+            if @output_collection.empty?
+              output = @output_hash
+            else
+              output = @output_collection
+              output << @output_hash unless @output_hash.empty?
+              output.flatten!
+            end
+            output
+          end
+
+          # In case if we want to solve collisions providing lambda to :merge option
+          def merge_strategy(for_merge)
+            if for_merge.respond_to? :call
+              for_merge
+            else
+              -> {}
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This also closes #138
Hi guys. Long time ago I dreamed about merging fields into nested hashes. And that's it. I found it useful and decided to make a PR. 

We can do this:
```ruby
expose :contact_info do
  expose :phone
  expose :address, merge: true, using: API::Entities::Address
end
```

this:
```ruby
expose :something_useful, merge: true
```

And even this:
```ruby
expose :profiles do
  expose :users, merge: true, using: API::Entities::User
  expose :admins, merge: true, using: API::Entities::Admin
end
```

It would be awesome if you take a look at this. Thanks!