### PR TITLE
Do not delegate to Kernel methods.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 language: ruby
 
 cache: bundler
+bundler_args: --without development
 
 rvm:
   - ruby-head

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.5.2 (Next)
 ============
 
+* [#215](https://github.com/ruby-grape/grape-entity/pull/217): `#delegate_attribute` should not delegate to methods included with `Kernel`. - [@maltoe](https://github.com/maltoe)
 * Your contribution here.
 
 0.5.1 (2016-4-4)

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :development do
 end
 
 group :development, :test do
+  gem 'rake'
   gem 'json'
   gem 'rspec'
   gem 'rack-test', '~> 0.6.2', require: 'rack/test'

--- a/Gemfile
+++ b/Gemfile
@@ -2,13 +2,16 @@ source 'http://rubygems.org'
 
 gemspec
 
-group :development, :test do
+group :development do
   gem 'pry'
   gem 'guard'
   gem 'guard-rspec'
   gem 'guard-bundler'
   gem 'rb-fsevent'
   gem 'growl'
+end
+
+group :development, :test do
   gem 'json'
   gem 'rspec'
   gem 'rack-test', '~> 0.6.2', require: 'rack/test'

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -478,7 +478,7 @@ module Grape
     end
 
     def delegate_attribute(attribute)
-      if respond_to?(attribute, true)
+      if respond_to?(attribute, true) && method(attribute).owner == self.class
         send(attribute)
       else
         delegator.delegate(attribute)

--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -1548,6 +1548,18 @@ describe Grape::Entity do
         expect(rep.value_for(:name)).to eq 'cooler name'
       end
 
+      it 'does not delegate to Kernel methods' do
+        module EntitySpec
+          class DelegatingEntity < Grape::Entity
+            expose :system
+          end
+        end
+
+        foo = double 'Foo', system: 'System'
+        rep = EntitySpec::DelegatingEntity.new foo
+        expect(rep.value_for(:system)).to eq 'System'
+      end
+
       context 'using' do
         before do
           module EntitySpec

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,4 @@ require 'bundler'
 
 Bundler.require :default, :test
 
-require 'pry'
-
 RSpec.configure(&:raise_errors_for_deprecations!)


### PR DESCRIPTION
This patch prevents Entity from delegating attributes
to Kernel methods. This is accomplished by testing the
methods the Entity class responds to for ownership
by the Entity class itself.

Fixes #215.