### PR TITLE
Add fetch method to fetch from opts_hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 * [#215](https://github.com/ruby-grape/grape-entity/pull/217): Fix: `#delegate_attribute` no longer delegates to methods included with `Kernel` - [@maltoe](https://github.com/maltoe).
 * [#219](https://github.com/ruby-grape/grape-entity/pull/219): Fix: double pass options in serializable_hash - [@sbatykov](https://github.com/sbatykov).
+* [#226](https://github.com/ruby-grape/grape-entity/pull/226): Add fetch method to fetch from opts_hash - [@alanjcfs](https://github.com/alanjcfs).
 * Your contribution here.
 
 0.5.1 (2016-4-4)

--- a/lib/grape_entity/options.rb
+++ b/lib/grape_entity/options.rb
@@ -15,6 +15,10 @@ module Grape
         @opts_hash[key]
       end
 
+      def fetch(*args)
+        @opts_hash.fetch(*args)
+      end
+
       def key?(key)
         @opts_hash.key? key
       end


### PR DESCRIPTION
We use `fetch` often to get options (raising an error if an option doesn't exist) as well as to provide a alternative value if an option is not provided.