### PR TITLE
Expose Hash objects with string keys

### DIFF
--- a/lib/grape_entity/delegator/hash_object.rb
+++ b/lib/grape_entity/delegator/hash_object.rb
@@ -3,7 +3,7 @@ module Grape
     module Delegator
       class HashObject < Base
         def delegate(attribute)
-          object[attribute]
+          object[attribute] || object[attribute.to_s]
         end
       end
     end

--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -626,6 +626,12 @@ describe Grape::Entity do
         expect(representation).to eq(awesome: true)
       end
 
+      it 'returns a serialized hash of a hash with string keys' do
+        subject.expose('awesome', 'data')
+        representation = subject.represent({ 'awesome' => true, 'data' => 'awesome' }, serializable: true)
+        expect(representation).to eq(awesome: true, data: 'awesome')
+      end
+
       it 'returns a serialized hash of an OpenStruct' do
         subject.expose(:awesome)
         representation = subject.represent(OpenStruct.new, serializable: true)


### PR DESCRIPTION
Fix #223: extracting of string keys for `Grape::Entity::Delegator::HashObject`. Now Hashes with string keys (database records with JSON fields for example) can be exposed correctly.
