### PR TITLE
Let the OutputBuilder be the Hash as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [#215](https://github.com/ruby-grape/grape-entity/pull/217): Fix: `#delegate_attribute` no longer delegates to methods included with `Kernel` - [@maltoe](https://github.com/maltoe).
 * [#219](https://github.com/ruby-grape/grape-entity/pull/219): Fix: double pass options in serializable_hash - [@sbatykov](https://github.com/sbatykov).
 * [#226](https://github.com/ruby-grape/grape-entity/pull/226): Add fetch method to fetch from opts_hash - [@alanjcfs](https://github.com/alanjcfs).
+* [#232](https://github.com/ruby-grape/grape-entity/pull/232): Add `#kind_of?` and `#is_a?` to `OutputBuilder` to get an exact class of an `output` object. [#213](https://github.com/ruby-grape/grape-entity/issues/213) - [@avyy](https://github.com/avyy).
 * Your contribution here.
 
 0.5.1 (2016-4-4)

--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,9 @@ end
 
 group :development, :test do
   gem 'rake'
-  gem 'json'
+  gem 'json', '~> 1.8.3'
   gem 'rspec'
+  gem 'rack', '~> 1.6.4'
   gem 'rack-test', '~> 0.6.2', require: 'rack/test'
   gem 'rubocop', '0.31.0'
 end

--- a/grape-entity.gemspec
+++ b/grape-entity.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = 'grape-entity'
 
-  s.add_runtime_dependency 'activesupport'
+  s.add_runtime_dependency 'activesupport', '< 5'
   s.add_runtime_dependency 'multi_json', '>= 1.3.2'
 
   s.add_development_dependency 'rake'

--- a/lib/grape_entity/exposure/nesting_exposure/output_builder.rb
+++ b/lib/grape_entity/exposure/nesting_exposure/output_builder.rb
@@ -25,6 +25,11 @@ module Grape
             end
           end
 
+          def kind_of?(klass)
+            klass == output.class || super
+          end
+          alias_method :is_a?, :kind_of?
+
           def __getobj__
             output
           end

--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -905,6 +905,7 @@ describe Grape::Entity do
 
         representation = subject.represent(4.times.map { Object.new }, serializable: true)
         expect(representation).to be_kind_of(Grape::Entity::Exposure::NestingExposure::OutputBuilder)
+        expect(representation).to be_kind_of(Hash)
         expect(representation).to have_key :my_items
         expect(representation[:my_items]).to be_kind_of Array
         expect(representation[:my_items].size).to be 4


### PR DESCRIPTION
 #213 
Hi everyone :suspect: 
The problem that we've changed the `Hash` output to the `OutputBuilder` one (see #204) . Even though an `OutputBuilder` instance delegates everything to its `output` object (which is a `Hash`) - it  returns `false` when we do this: `.is_a?(Hash)` on a `OutputBuilder` instance. `is_a?` method is not delegated. And grape errors formatters expect to get a `Hash` instance from `Entity` after representation, not `OutputBuilder` one.

I checked grape master branch and my grape-entity branch tests. Everything should be fine.