### PR TITLE
Allow methods from ancestors of the entity

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,7 +12,7 @@ Metrics/AbcSize:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 202
+  Max: 206
 
 # Offense count: 3
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.5.2 (Next)
 ============
 
+* [#238](https://github.com/ruby-grape/grape-entity/pull/238): `#delegate_attribute` delegates to methods included from inherited entities - [@anakinj](https://github.com/anakinj).
 * [#215](https://github.com/ruby-grape/grape-entity/pull/217): Fix: `#delegate_attribute` no longer delegates to methods included with `Kernel` - [@maltoe](https://github.com/maltoe).
 * [#219](https://github.com/ruby-grape/grape-entity/pull/219): Fix: double pass options in serializable_hash - [@sbatykov](https://github.com/sbatykov).
 * [#226](https://github.com/ruby-grape/grape-entity/pull/226): Added fetch method to fetch from opts_hash - [@alanjcfs](https://github.com/alanjcfs).

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -478,11 +478,16 @@ module Grape
     end
 
     def delegate_attribute(attribute)
-      if respond_to?(attribute, true) && method(attribute).owner == self.class
+      if respond_to?(attribute, true) && entity_method?(attribute)
         send(attribute)
       else
         delegator.delegate(attribute)
       end
+    end
+
+    def entity_method?(attribute)
+      method_owner = method(attribute).owner
+      self.class == method_owner || self.class.ancestors[0..self.class.ancestors.find_index(Grape::Entity) - 1].include?(method_owner)
     end
 
     alias_method :as_json, :serializable_hash

--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -1561,6 +1561,26 @@ describe Grape::Entity do
         expect(rep.value_for(:system)).to eq 'System'
       end
 
+      it 'allows methods to be inherited' do
+        module EntitySpec
+          class ParentEntity < Grape::Entity
+            expose :parent
+
+            private
+
+            def parent
+              'I am the parent'
+            end
+          end
+
+          class ChildEntity < ParentEntity; end
+        end
+
+        foo = double('Foo', value: 'test')
+        rep = EntitySpec::ChildEntity.new foo
+        expect(rep.value_for(:parent)).to eq 'I am the parent'
+      end
+
       context 'using' do
         before do
           module EntitySpec


### PR DESCRIPTION
Had a little problem with inherited entities and changes done in #217. This should allow the method to be in a inherited class up until the Grape::Entity class.