### PR TITLE
Fix nil values causing errors when merge option passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Fixes
 
+* [#248](https://github.com/ruby-grape/grape-entity/pull/248): Fix `nil` values causing errors when `merge` option passed - [@arempe93](https://github.com/arempe93).
 * Your contribution here.
 
 ### 0.5.2 (2016-11-14)

--- a/lib/grape_entity/exposure/nesting_exposure/output_builder.rb
+++ b/lib/grape_entity/exposure/nesting_exposure/output_builder.rb
@@ -17,6 +17,7 @@ module Grape
               # If we have an array which should not be merged - save it with a key as a hash
               # If we have hash which should be merged - save it without a key (merge)
               if exposure.for_merge
+                return unless result
                 @output_hash.merge! result, &merge_strategy(exposure.for_merge)
               else
                 @output_hash[exposure.key] = result

--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -50,6 +50,18 @@ describe Grape::Entity do
           subject.expose(:special, merge: ->(_, v1, v2) { v1 && v2 ? 'brand new val' : v2 })
           expect(subject.represent(nested_hash).serializable_hash).to eq(like_nested_hash: 'brand new val')
         end
+
+        context 'and nested object is nil' do
+          let(:nested_hash) do
+            { something: nil, special: { like_nested_hash: '12' } }
+          end
+
+          it 'adds nothing to output' do
+            subject.expose(:something, merge: true)
+            subject.expose(:special)
+            expect(subject.represent(nested_hash).serializable_hash).to eq(special: { like_nested_hash: '12' })
+          end
+        end
       end
 
       context 'with a block' do


### PR DESCRIPTION
Currently, if something is exposed with `merge: true` and the value ends up being `nil`, it raises an unhandled exception. This changes that behavior to add nothing to the output and throw no exception