### PR TITLE
Avoid noise when code runs with Ruby warnings

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,7 +13,7 @@ Metrics/AbcSize:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 206
+  Max: 208
 
 # Offense count: 3
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 #### Features
 
-* Your contrbution here.
+* Your contribution here.
 
 #### Fixes
 
-* Your contrbution here.
+* [#251](https://github.com/ruby-grape/grape-entity/pull/251): Avoid noise when code runs with Ruby warnings - [@cpetschnig](https://github.com/cpetschnig).
+* Your contribution here.
 
 ### 0.6.0 (2016-11-20)
 

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -392,6 +392,7 @@ module Grape
     # @option options :only [Array] all the fields that should be returned
     # @option options :except [Array] all the fields that should not be returned
     def self.represent(objects, options = {})
+      @present_collection ||= nil
       if objects.respond_to?(:to_ary) && !@present_collection
         root_element = root_element(:collection_root)
         inner = objects.to_ary.map { |object| new(object, options.reverse_merge(collection: true)).presented }
@@ -409,8 +410,9 @@ module Grape
     # This method returns the entity's root or collection root node, or its parent's
     # @param root_type: either :collection_root or just :root
     def self.root_element(root_type)
-      if instance_variable_get("@#{root_type}")
-        instance_variable_get("@#{root_type}")
+      instance_variable = "@#{root_type}"
+      if instance_variable_defined?(instance_variable) && instance_variable_get(instance_variable)
+        instance_variable_get(instance_variable)
       elsif superclass.respond_to? :root_element
         superclass.root_element(root_type)
       end

--- a/lib/grape_entity/exposure/nesting_exposure/nested_exposures.rb
+++ b/lib/grape_entity/exposure/nesting_exposure/nested_exposures.rb
@@ -7,6 +7,7 @@ module Grape
 
           def initialize(exposures)
             @exposures = exposures
+            @deep_complex_nesting = nil
           end
 
           def find_by(attribute)


### PR DESCRIPTION
New versions of RSpec have warnings turned on by default:

    # This setting enables warnings. It's recommended, but in some cases may
    # be too noisy due to issues in dependencies.
    config.warnings = true

I believe these warnings are helpful in general to write better code. However, Grape Entity is very noisy. I get more than 10 lines of warnings for one single test where Grape Entity is involved.

I hope you agree. Some of my changes could also be solved differently for sure. I am happy to discuss and change those cases. I also turned warnings on in the test suite.