### PR TITLE
Relax minimal Ruby version requirement

### DIFF
--- a/grape-entity.gemspec
+++ b/grape-entity.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.description = 'Extracted from Grape, A Ruby framework for rapid API development with great conventions.'
   s.license     = 'MIT'
 
-  s.required_ruby_version = '>= 2.2.6'
+  s.required_ruby_version = '>= 2.2'
 
   s.rubyforge_project = 'grape-entity'
 


### PR DESCRIPTION
Ruby 2.2 is still alive and fixing minimal version to 2.2.6 would cause many issues for applications out there that are still on older version of series 2.2