### PR TITLE
Freeze rubocop version for stable CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'http://rubygems.org'
 gemspec
 
 group :development, :test do
-  gem 'rubocop', require: false
+  gem 'rubocop', '~> 0.48.0', require: false
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'http://rubygems.org'
 
 gemspec
 
-group :development do
+group :development, :test do
   gem 'rubocop', require: false
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,10 @@ source 'http://rubygems.org'
 
 gemspec
 
+group :development do
+  gem 'rubocop', require: false
+end
+
 group :test do
   gem 'coveralls', require: false
   gem 'growl'

--- a/grape-entity.gemspec
+++ b/grape-entity.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'rubocop', '~> 0.48.0'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'maruku'

--- a/grape-entity.gemspec
+++ b/grape-entity.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'rubocop', '~> 0.48'
+  s.add_development_dependency 'rubocop', '~> 0.48.0'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'maruku'


### PR DESCRIPTION
ref: https://github.com/bbatsov/rubocop/commit/dd0d60c0a87bdb6233cdeca14a13505b10f2bfae

https://github.com/ruby-grape/grape-entity/pull/277 failed as https://travis-ci.org/ruby-grape/grape-entity/jobs/295161671 from rubocop 0.48~0.51 changes.