### PR TITLE
Fix wrong argument exception when &:block passed to the expose method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 #### Fixes
 
+* [#288](https://github.com/ruby-grape/grape-entity/pull/288) Fix wrong argument exception when &:block passed to the expose method  - [@DmitryTsepelev](https://github.com/DmitryTsepelev)
+
 * Your contribution here.
 
 ### 0.6.1 (2017-01-09)

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -492,7 +492,11 @@ module Grape
     end
 
     def exec_with_object(options, &block)
-      instance_exec(object, options, &block)
+      if block.parameters.count == 1
+        instance_exec(object, &block)
+      else
+        instance_exec(object, options, &block)
+      end
     end
 
     def exec_with_attribute(attribute, &block)

--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -114,6 +114,30 @@ describe Grape::Entity do
           end
         end
 
+        context 'with block passed via &' do
+          it 'with does not pass options when block is passed via &' do
+            class SomeObject
+              def method_without_args
+                'result'
+              end
+            end
+
+            subject.expose :that_method_without_args do |object|
+              object.method_without_args
+            end
+
+            subject.expose :that_method_without_args_again, &:method_without_args
+
+            object = SomeObject.new
+
+            value = subject.represent(object).value_for(:that_method_without_args)
+            expect(value).to eq('result')
+
+            value2 = subject.represent(object).value_for(:that_method_without_args_again)
+            expect(value2).to eq('result')
+          end
+        end
+
         context 'with no parameters passed to the block' do
           it 'adds a nested exposure' do
             subject.expose :awesome do


### PR DESCRIPTION
I've faced this problem when Rubocop suggested to fix `Style/SymbolProc` problem in the following code:

```ruby
expose :something do |object|
  object.any_method
end
```

After the fix the following code started to throw wrong argument number exception, because options are always passed to the block:
```ruby
expose :something, &:any_method
```

I'm aware of the `as:` option which solves the case above, but probably this enhancement will help avoid confusion with Rubocop users.