### PR TITLE
Loosens ActiveSupport to >= 3.0.0. Fixes #289

### DIFF
--- a/grape-entity.gemspec
+++ b/grape-entity.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = 'grape-entity'
 
-  s.add_runtime_dependency 'activesupport', '>= 4.0.0'
+  s.add_runtime_dependency 'activesupport', '>= 3.0.0'
   s.add_runtime_dependency 'multi_json', '>= 1.3.2'
 
   s.add_development_dependency 'bundler'


### PR DESCRIPTION
All the tests pass. `bundle exec rake` has some rubocop reports but they're not related to the change.