### PR TITLE
Allow replace non-conditional non-nesting exposures in child classes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,7 +18,7 @@ Metrics/AbcSize:
 # Offense count: 35
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
-  Max: 1489
+  Max: 1496
 
 # Offense count: 2
 # Configuration parameters: CountComments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
 #### Fixes
 
 * [#288](https://github.com/ruby-grape/grape-entity/pull/288) Fix wrong argument exception when &:block passed to the expose method  - [@DmitryTsepelev](https://github.com/DmitryTsepelev).
-* [#291](https://github.com/ruby-grape/grape-entity/pull/291) Refactor and simplify various classes and modules
+* [#291](https://github.com/ruby-grape/grape-entity/pull/291) Refactor and simplify various classes and modules  - [@DmitryTsepelev](https://github.com/DmitryTsepelev).
+* [#292](https://github.com/ruby-grape/grape-entity/pull/292): Allow replace non-conditional non-nesting exposures in child classes (fixes  [#286](https://github.com/ruby-grape/grape-entity/issues/286)) - [@DmitryTsepelev](https://github.com/DmitryTsepelev).
 * Your contribution here.
 
 ### 0.6.1 (2017-01-09)

--- a/lib/grape_entity/exposure/base.rb
+++ b/lib/grape_entity/exposure/base.rb
@@ -116,6 +116,10 @@ module Grape
           end
         end
 
+        def replaceable_by?(other)
+          !nesting? && !conditional? && !other.nesting? && !other.conditional?
+        end
+
         protected
 
         attr_reader :options

--- a/lib/grape_entity/exposure/nesting_exposure/nested_exposures.rb
+++ b/lib/grape_entity/exposure/nesting_exposure/nested_exposures.rb
@@ -16,6 +16,10 @@ module Grape
             @exposures.find { |e| e.attribute == attribute }
           end
 
+          def select_by(attribute)
+            @exposures.select { |e| e.attribute == attribute }
+          end
+
           def <<(exposure)
             reset_memoization!
             @exposures << exposure

--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -352,6 +352,15 @@ describe Grape::Entity do
           expect(subject.represent({ name: 'bar' }, serializable: true)).to eq(email: nil, name: 'bar')
           expect(child_class.represent({ name: 'bar' }, serializable: true)).to eq(email: nil, name: 'foo')
         end
+
+        it 'overrides parent class exposure' do
+          subject.expose :name
+          child_class = Class.new(subject)
+          child_class.expose :name, as: :child_name
+
+          expect(subject.represent({ name: 'bar' }, serializable: true)).to eq(name: 'bar')
+          expect(child_class.represent({ name: 'bar' }, serializable: true)).to eq(child_name: 'bar')
+        end
       end
 
       context 'register formatters' do


### PR DESCRIPTION
Tried to fix issue #286 by allowing to override exposures in child classes when the exposure is not conditional and not nesting