### PR TITLE
Add expose_nil option

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,7 +18,7 @@ Metrics/AbcSize:
 # Offense count: 35
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
-  Max: 1496
+  Max: 1625
 
 # Offense count: 2
 # Configuration parameters: CountComments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#264](https://github.com/ruby-grape/grape-entity/pull/264): Adds Rubocop config and todo list - [@james2m](https://github.com/james2m).
 * [#255](https://github.com/ruby-grape/grape-entity/pull/255): Adds code coverage w/ coveralls - [@LeFnord](https://github.com/LeFnord).
 * [#268](https://github.com/ruby-grape/grape-entity/pull/268): Loosens the version dependency for activesupport - [@anakinj](https://github.com/anakinj).
+* [#293](https://github.com/ruby-grape/grape-entity/pull/293): Adds expose_nil option - [@b-boogaard](https://github.com/b-boogaard).
 
 * Your contribution here.
 

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ module Entities
     with_options(format_with: :iso_timestamp) do
       expose :created_at
       expose :updated_at
-    end    
+    end
   end
 end
 ```
@@ -346,6 +346,86 @@ module Entities
 
   class AnotherModel < Grape::Entity
     expose :created_at, format_with: :utc
+  end
+end
+```
+
+#### Expose Nil
+
+By default, exposures that contain `nil` values will be represented in the resulting JSON as `null`.
+
+As an example, a hash with the following values:
+
+```ruby
+{
+  name: nil,
+  age: 100
+}
+```
+
+will result in a JSON object that looks like:
+
+```javascript
+{
+  "name": null,
+  "age": 100
+}
+```
+
+There are also times when, rather than displaying an attribute with a `null` value, it is more desirable to not display the attribute at all. Using the hash from above the desired JSON would look like:
+
+```javascript
+{
+  "age": 100
+}
+```
+
+In order to turn on this behavior for an as-exposure basis, the option `expose_nil` can be used. By default, `expose_nil` is considered to be `true`, meaning that `nil` values will be represented in JSON as `null`. If `false` is provided, then attributes with `nil` values will be omitted from the resulting JSON completely.
+
+```ruby
+module  Entities
+  class MyModel < Grape::Entity
+    expose :name, expose_nil: false
+    expose :age, expose_nil: false
+  end
+end
+```
+
+`expose_nil` is per exposure, so you can suppress exposures from resulting in `null` or express `null` values on a per exposure basis as you need:
+
+```ruby
+module  Entities
+  class MyModel < Grape::Entity
+    expose :name, expose_nil: false
+    expose :age # since expose_nil is omitted nil values will be rendered as null
+  end
+end
+```
+
+It is also possible to use `expose_nil` with `with_options` if you want to add the configuration to multiple exposures at once.
+
+```ruby
+module  Entities
+  class MyModel < Grape::Entity
+    # None of the exposures in the with_options block will render nil values as null
+    with_options(expose_nil: false) do
+      expose :name
+      expose :age
+    end
+  end
+end
+```
+
+When using `with_options`, it is possible to again override which exposures will render `nil` as `null` by adding the option on a specific exposure.
+
+```ruby
+module  Entities
+  class MyModel < Grape::Entity
+    # None of the exposures in the with_options block will render nil values as null
+    with_options(expose_nil: false) do
+      expose :name
+      expose :age, expose_nil: true # nil values would be rendered as null in the JSON
+    end
   end
 end
 ```

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -126,6 +126,9 @@ module Grape
     # This method is the primary means by which you will declare what attributes
     # should be exposed by the entity.
     #
+    # @option options :expose_nil When set to false the associated exposure will not
+    #   be rendered if its value is nil.
+    #
     # @option options :as Declare an alias for the representation of this attribute.
     #   If a proc is presented it is evaluated in the context of the entity so object
     #   and the entity methods are available to it.
@@ -170,6 +173,7 @@ module Grape
 
       if args.size > 1
         raise ArgumentError, 'You may not use the :as option on multi-attribute exposures.' if options[:as]
+        raise ArgumentError, 'You may not use the :expose_nil on multi-attribute exposures.' if options.key?(:expose_nil)
         raise ArgumentError, 'You may not use block-setting on multi-attribute exposures.' if block_given?
       end
 
@@ -523,7 +527,7 @@ module Grape
 
     # All supported options.
     OPTIONS = %i[
-      rewrite as if unless using with proc documentation format_with safe attr_path if_extras unless_extras merge
+      rewrite as if unless using with proc documentation format_with safe attr_path if_extras unless_extras merge expose_nil
     ].to_set.freeze
 
     # Merges the given options with current block options.


### PR DESCRIPTION
Addresses #216 and #10 

I read through both of the issues to help guide naming, default behavior etc. 

Some basic high level details
* expose_nil defaults to true
* is implemented as an unless condition
* the option is transformed as part of Exposure.compile_conditions

Currently rubocop is failing because my new tests make the `describe` block too long. I'm not sure how you all typically handle something like this so just let me know what I should do.

```
Running RuboCop...
Inspecting 38 files
...............................C......

Offenses:

spec/grape_entity/entity_spec.rb:6:1: C: Metrics/BlockLength: Block has too many lines. [1625/1496]
describe Grape::Entity do ...
^^^^^^^^^^^^^^^^^^^^^^^^^

38 files inspected, 1 offense detected
RuboCop failed!
```