### PR TITLE
Introduce override option for expose

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,7 +18,7 @@ Metrics/AbcSize:
 # Offense count: 35
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
-  Max: 1625
+  Max: 1632
 
 # Offense count: 2
 # Configuration parameters: CountComments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Features
 
+* [#292](https://github.com/ruby-grape/grape-entity/pull/297): Introduce `override` option for expose (fixes [#286](https://github.com/ruby-grape/grape-entity/issues/296)) - [@DmitryTsepelev](https://github.com/DmitryTsepelev).
 * Your contribution here.
 
 #### Fixes

--- a/README.md
+++ b/README.md
@@ -256,6 +256,22 @@ class MailingAddress < UserData
 end
 ```
 
+#### Overriding exposures
+
+If you want to add one more exposure for the field but don't want the first one to be fired (for instance, when using inheritance), you can use the `override` flag. For instance:
+
+```ruby
+class User < Grape::Entity
+  expose :name
+end
+
+class Employee < UserData
+  expose :name, as: :employee_name, override: true
+end
+```
+
+`User` will return something like this `{ "name" : "John" }` while `Employee` will present the same data as `{ "employee_name" : "John" }` instead of `{ "name" : "John", "employee_name" : "John" }`.
+
 #### Returning only the fields you want
 
 After exposing the desired attributes, you can choose which one you need when representing some object or collection by using the only: and except: options. See the example:

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -197,7 +197,7 @@ module Grape
 
       exposure = Exposure.new(attribute, options)
 
-      exposure_list.delete_by(attribute) if exposure_list.select_by(attribute).all? { |exp| exp.replaceable_by?(exposure) }
+      exposure_list.delete_by(attribute) if exposure.override?
 
       exposure_list << exposure
 
@@ -527,7 +527,7 @@ module Grape
 
     # All supported options.
     OPTIONS = %i[
-      rewrite as if unless using with proc documentation format_with safe attr_path if_extras unless_extras merge expose_nil
+      rewrite as if unless using with proc documentation format_with safe attr_path if_extras unless_extras merge expose_nil override
     ].to_set.freeze
 
     # Merges the given options with current block options.

--- a/lib/grape_entity/exposure/base.rb
+++ b/lib/grape_entity/exposure/base.rb
@@ -4,7 +4,7 @@ module Grape
   class Entity
     module Exposure
       class Base
-        attr_reader :attribute, :is_safe, :documentation, :conditions, :for_merge
+        attr_reader :attribute, :is_safe, :documentation, :override, :conditions, :for_merge
 
         def self.new(attribute, options, conditions, *args, &block)
           super(attribute, options, conditions).tap { |e| e.setup(*args, &block) }
@@ -19,6 +19,7 @@ module Grape
           @for_merge = options[:merge]
           @attr_path_proc = options[:attr_path]
           @documentation = options[:documentation]
+          @override = options[:override]
           @conditions = conditions
         end
 
@@ -116,8 +117,8 @@ module Grape
           end
         end
 
-        def replaceable_by?(other)
-          !nesting? && !conditional? && !other.nesting? && !other.conditional?
+        def override?
+          @override
         end
 
         protected

--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -477,10 +477,19 @@ describe Grape::Entity do
           expect(child_class.represent({ name: 'bar' }, serializable: true)).to eq(email: nil, name: 'foo')
         end
 
-        it 'overrides parent class exposure' do
+        it 'not overrides exposure by default' do
           subject.expose :name
           child_class = Class.new(subject)
           child_class.expose :name, as: :child_name
+
+          expect(subject.represent({ name: 'bar' }, serializable: true)).to eq(name: 'bar')
+          expect(child_class.represent({ name: 'bar' }, serializable: true)).to eq(name: 'bar', child_name: 'bar')
+        end
+
+        it 'overrides parent class exposure when option is specified' do
+          subject.expose :name
+          child_class = Class.new(subject)
+          child_class.expose :name, as: :child_name, override: true
 
           expect(subject.represent({ name: 'bar' }, serializable: true)).to eq(name: 'bar')
           expect(child_class.represent({ name: 'bar' }, serializable: true)).to eq(child_name: 'bar')


### PR DESCRIPTION
Per discussion here https://github.com/ruby-grape/grape-entity/issues/296. Please note that I've removed all other conditions, so even conditional or nesting exposure can be overwritten (should I throw an error or something when people configure their exposures in strange ways?)