### PR TITLE
support multiple merge fields

### DIFF
--- a/lib/grape_entity/exposure/nesting_exposure/output_builder.rb
+++ b/lib/grape_entity/exposure/nesting_exposure/output_builder.rb
@@ -53,7 +53,7 @@ module Grape
             if for_merge.respond_to? :call
               for_merge
             else
-              -> {}
+              ->(k, v1, v2){ v2 }
             end
           end
         end


### PR DESCRIPTION
I want to use like this
```ruby
expose :config1, merge: true, using: ApplicationEntity
expose :config2, merge: true, using: ApplicationEntity
```
but I must use like this
```ruby
expose :config1, merge: true, using: ApplicationEntity
expose :config2, merge: ->(k, v1, v2) { v2 }, using: ApplicationEntity
```