### PR TITLE
CI: Define matrix one way

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,5 @@ matrix:
   fast_finish: true
 
   allow_failures:
-    - rvm: 2.3.8
     - rvm: ruby-head
     - rvm: jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,21 @@
-sudo: false
-
 language: ruby
 
 before_install:
-  - gem update --system
   - gem install bundler
 
 after_success:
-  # - coveralls
   - bundle exec danger
 
 rvm:
+  - 2.3.8
   - 2.4.5
   - 2.5.3
   - 2.6.0
+  - ruby-head
+  - jruby-head
 
 matrix:
   fast_finish: true
-
-  include:
-    - rvm: 2.3.8
-    - rvm: ruby-head
-    - rvm: jruby-head
 
   allow_failures:
     - rvm: 2.3.8


### PR DESCRIPTION
  - this keeps CI matrix creation in "rvm" settings
  - trust RVM to have updated RubyGems