### PR TITLE
Add options usage notes to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,8 @@ class ExampleEntity < Grape::Entity
 end
 ```
 
-You have always access to the presented instance with `object`
+You always have access to the presented instance (`object`) and the top-level
+entity options (`options`).
 
 ```ruby
 class ExampleEntity < Grape::Entity
@@ -229,7 +230,7 @@ class ExampleEntity < Grape::Entity
   private
 
   def formatted_value
-    "+ X #{object.value}"
+    "+ X #{object.value} #{options[:y]}"
   end
 end
 ```


### PR DESCRIPTION
In addition to `object`, the entity options are available to access via this [attr_reader](https://github.com/ruby-grape/grape-entity/blob/master/lib/grape_entity/entity.rb#L47)

Some context - 

We had a PR with logic in it that looked like:

```
# .../api.rb
class Api
  resources ... do
    get '...' do
      present resource, with: ....Entity, variant: params[:variant]
    end
  end
end

# .../...entity.rb
class ...Entity
  expose :html do |_, options|
    @variant = options[:variant]
    html
  end

private

  def html
    ...FetchHtml.call(resource: resource, variant: @variant)`
  end
end
```

Instead of:

```
# .../...entity.rb
class ...Entity
  expose :html

private

  def html
    ...FetchHtml.call(resource: resource, variant: options[:variant])`
  end
end
```

The concern with using `options` directly was that it wasn't documented.

I didn't update the CHANGELOG since this is just a README update.