### PR TITLE
Support hashes with string keys

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ AllCops:
 Layout/EmptyLinesAroundArguments:
   Enabled: false
 
-Layout/IndentHash:
+Layout/IndentFirstHashElement:
   EnforcedStyle: consistent
 
 Metrics/AbcSize:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Next
 
+* [#319](https://github.com/ruby-grape/grape-entity/pull/319): Support hashes with string keys - [@mhenrixon](https://github.com/mhenrixon).
+
 #### Features
 
 * Your contribution here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,21 @@
 ### Next
 
-* [#319](https://github.com/ruby-grape/grape-entity/pull/319): Support hashes with string keys - [@mhenrixon](https://github.com/mhenrixon).
-
 #### Features
 
 * Your contribution here.
+* [#319](https://github.com/ruby-grape/grape-entity/pull/319): Support hashes with string keys - [@mhenrixon](https://github.com/mhenrixon).
 * [#300](https://github.com/ruby-grape/grape-entity/pull/300): Loosens activesupport to 3 - [@ericschultz](https://github.com/ericschultz).
 
 #### Fixes
 
 * Your contribution here.
-* [#258](https://github.com/ruby-grape/grape-entity/pull/307): Allow exposures to call methods defined in modules included in an entity [@robertoz-01](https://github.com/robertoz-01).
+* [#307](https://github.com/ruby-grape/grape-entity/pull/307): Allow exposures to call methods defined in modules included in an entity [@robertoz-01](https://github.com/robertoz-01).
 
 ### 0.7.1 (2018-01-30)
 
 #### Features
 
-* [#292](https://github.com/ruby-grape/grape-entity/pull/297): Introduce `override` option for expose (fixes [#286](https://github.com/ruby-grape/grape-entity/issues/296)) - [@DmitryTsepelev](https://github.com/DmitryTsepelev).
+* [#297](https://github.com/ruby-grape/grape-entity/pull/297): Introduce `override` option for expose (fixes [#286](https://github.com/ruby-grape/grape-entity/issues/296)) - [@DmitryTsepelev](https://github.com/DmitryTsepelev).
 
 ### 0.7.0 (2018-01-25)
 

--- a/lib/grape_entity/delegator/fetchable_object.rb
+++ b/lib/grape_entity/delegator/fetchable_object.rb
@@ -4,7 +4,7 @@ module Grape
   class Entity
     module Delegator
       class FetchableObject < Base
-        def delegate(attribute)
+        def delegate(attribute, **)
           object.fetch attribute
         end
       end

--- a/lib/grape_entity/delegator/hash_object.rb
+++ b/lib/grape_entity/delegator/hash_object.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
+require 'pry'
+
 module Grape
   class Entity
     module Delegator
       class HashObject < Base
-        def delegate(attribute)
-          object[attribute]
+        def delegate(attribute, hash_access: :to_sym)
+          object[attribute.send(hash_access)]
         end
       end
     end

--- a/lib/grape_entity/delegator/openstruct_object.rb
+++ b/lib/grape_entity/delegator/openstruct_object.rb
@@ -4,7 +4,7 @@ module Grape
   class Entity
     module Delegator
       class OpenStructObject < Base
-        def delegate(attribute)
+        def delegate(attribute, **)
           object.send attribute
         end
       end

--- a/lib/grape_entity/delegator/plain_object.rb
+++ b/lib/grape_entity/delegator/plain_object.rb
@@ -4,7 +4,7 @@ module Grape
   class Entity
     module Delegator
       class PlainObject < Base
-        def delegate(attribute)
+        def delegate(attribute, **)
           object.send attribute
         end
 

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -114,6 +114,22 @@ module Grape
       end
 
       attr_writer :formatters
+
+      def hash_access
+        @hash_access ||= :to_sym
+      end
+
+      def hash_access=(value)
+        @hash_access =
+          case value
+          when :to_s, :str, :string
+            :to_s
+          when :to_sym, :sym, :symbol
+            :to_sym
+          else
+            :to_sym
+          end
+      end
     end
 
     @formatters = {}
@@ -459,8 +475,8 @@ module Grape
 
     def initialize(object, options = {})
       @object = object
-      @delegator = Delegator.new(object)
       @options = options.is_a?(Options) ? options : Options.new(options)
+      @delegator = Delegator.new(object)
     end
 
     def root_exposures
@@ -514,7 +530,7 @@ module Grape
       if is_defined_in_entity?(attribute)
         send(attribute)
       else
-        delegator.delegate(attribute)
+        delegator.delegate(attribute, hash_access: self.class.hash_access)
       end
     end
 


### PR DESCRIPTION
Before this change the only way I could find to access a hash with string keys
was to either convert it to a symbol hash or define methods in the entity.

This should at least allow the entire hash to be accessed with string keys yet default to existing behavior (symbol keys).

If anyone has suggestions for how to improve this I'm all ears. This was just the quickest least intrusive thing I could think of at the time.