### PR TITLE
Fix RuboCop issues

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ AllCops:
 Layout/EmptyLinesAroundArguments:
   Enabled: false
 
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 
 Metrics/AbcSize:

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -185,7 +185,7 @@ module Grape
     #   field, typically the value is a hash with two fields, type and desc.
     # @option options :merge This option allows you to merge an exposed field to the root
     #
-    # rubocop:disable Metrics/LineLength, Style/IfUnlessModifier
+    # rubocop:disable Metrics/LineLength
     def self.expose(*args, &block)
       options = merge_options(args.last.is_a?(Hash) ? args.pop : {})
 
@@ -212,7 +212,7 @@ module Grape
       @nesting_stack ||= []
       args.each { |attribute| build_exposure_for_attribute(attribute, @nesting_stack, options, block) }
     end
-    # rubocop:enable Metrics/LineLength, Style/IfUnlessModifier
+    # rubocop:enable Metrics/LineLength
 
     def self.build_exposure_for_attribute(attribute, nesting_stack, options, block)
       exposure_list = nesting_stack.empty? ? root_exposures : nesting_stack.last.nested_exposures


### PR DESCRIPTION
Hi!

This PR contains the following fixes for RuboCop:

- Follow up RuboCop v0.77 
  - The `Layout/IndentFirstHashElement` cop has renamed to `Layout/FirstHashElementIndentation` (https://github.com/rubocop-hq/rubocop/pull/7468).
- Remove the unnecessary disabling of `Style/IfUnlessModifier` cop to resolve the failed CI:
  - https://travis-ci.org/ruby-grape/grape-entity/jobs/606754710