### PR TITLE
Option expose_nil doesn't work when block is passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#329](https://github.com/ruby-grape/grape-entity/pull/329): Option expose_nil doesn't work when block is passed - [@serbiant](https://github.com/serbiant).
 * [#320](https://github.com/ruby-grape/grape-entity/pull/320): Gemspec: drop eol'd property rubyforge_project - [@olleolleolle](https://github.com/olleolleolle).
 * [#307](https://github.com/ruby-grape/grape-entity/pull/307): Allow exposures to call methods defined in modules included in an entity [@robertoz-01](https://github.com/robertoz-01).
 

--- a/lib/grape_entity/exposure.rb
+++ b/lib/grape_entity/exposure.rb
@@ -47,14 +47,20 @@ module Grape
             options[:unless]
           ].compact.flatten.map { |cond| Condition.new_unless(cond) }
 
-          unless_conditions << expose_nil_condition(attribute) if options[:expose_nil] == false
+          unless_conditions << expose_nil_condition(attribute, options) if options[:expose_nil] == false
 
           if_conditions + unless_conditions
         end
 
-        def expose_nil_condition(attribute)
+        def expose_nil_condition(attribute, options)
           Condition.new_unless(
-            proc { |object, _options| Delegator.new(object).delegate(attribute).nil? }
+            proc do |object, _options|
+              if options[:proc].nil?
+                Delegator.new(object).delegate(attribute).nil?
+              else
+                exec_with_object(options, &options[:proc]).nil?
+              end
+            end
           )
         end
 

--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -126,6 +126,26 @@ describe Grape::Entity do
               expect { subject.expose(:a, :b, :c, expose_nil: false) }.to raise_error ArgumentError
             end
           end
+
+          context 'when expose_nil option is false and block passed' do
+            it 'does not expose if block returns nil' do
+              subject.expose(:a, expose_nil: false) do |_obj, _options|
+                nil
+              end
+              subject.expose(:b)
+              subject.expose(:c)
+              expect(subject.represent(model).serializable_hash).to eq(b: nil, c: 'value')
+            end
+
+            it 'exposes is block returns a value' do
+              subject.expose(:a, expose_nil: false) do |_obj, _options|
+                100
+              end
+              subject.expose(:b)
+              subject.expose(:c)
+              expect(subject.represent(model).serializable_hash).to eq(a: 100, b: nil, c: 'value')
+            end
+          end
         end
 
         context 'when model is a hash' do


### PR DESCRIPTION
Greetings,

I've been trying to implement a conditional exposure at one of the entities in my project.
Noticed that in the current implementation, this code 

```ruby
expose :personal_details, expose_nil: false do |address, options|
  if options[:one_option].present?
    Public::Entities::PersonalDetail.represent address.personal_details
  elsif options[another_option].present?
    Public::Entities::PersonalDetailShort.represent address.personal_details
  else
    nil # explicit for the example
  end
end
```
will eventually expose `null` if both conditions are not satisfied.

This PR fixes the specified issue.
