### PR TITLE
CI: Use 2.5.7,  2.6.5, 2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rvm:
   - 2.4.9
   - 2.5.7
   - 2.6.5
+  - 2.7.0
   - ruby-head
   - jruby-head
 
@@ -17,5 +18,6 @@ matrix:
   fast_finish: true
 
   allow_failures:
+    - rvm: 2.4.9
     - rvm: ruby-head
     - rvm: jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ after_success:
   - bundle exec danger
 
 rvm:
-  - 2.4.5
-  - 2.5.4
-  - 2.6.2
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
   - ruby-head
   - jruby-head
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#330](https://github.com/ruby-grape/grape-entity/pull/330): CI: use Ruby 2.4.9, 2.5.7, 2.6.5 - [@budnik](https://github.com/budnik).
 * [#329](https://github.com/ruby-grape/grape-entity/pull/329): Option expose_nil doesn't work when block is passed - [@serbiant](https://github.com/serbiant).
 * [#320](https://github.com/ruby-grape/grape-entity/pull/320): Gemspec: drop eol'd property rubyforge_project - [@olleolleolle](https://github.com/olleolleolle).
 * [#307](https://github.com/ruby-grape/grape-entity/pull/307): Allow exposures to call methods defined in modules included in an entity - [@robertoz-01](https://github.com/robertoz-01).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 #### Fixes
 
 * Your contribution here.
-* [#330](https://github.com/ruby-grape/grape-entity/pull/330): CI: use Ruby 2.4.9, 2.5.7, 2.6.5 - [@budnik](https://github.com/budnik).
+* [#330](https://github.com/ruby-grape/grape-entity/pull/330): CI: use Ruby 2.5.7, 2.6.5, 2.7.0 - [@budnik](https://github.com/budnik).
 * [#329](https://github.com/ruby-grape/grape-entity/pull/329): Option expose_nil doesn't work when block is passed - [@serbiant](https://github.com/serbiant).
 * [#320](https://github.com/ruby-grape/grape-entity/pull/320): Gemspec: drop eol'd property rubyforge_project - [@olleolleolle](https://github.com/olleolleolle).
 * [#307](https://github.com/ruby-grape/grape-entity/pull/307): Allow exposures to call methods defined in modules included in an entity - [@robertoz-01](https://github.com/robertoz-01).

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'http://rubygems.org'
 gemspec
 
 group :development, :test do
-  gem 'rubocop', '~> 0.65', require: false
+  gem 'rubocop', '~> 0.74.0', require: false
 end
 
 group :test do


### PR DESCRIPTION
Previous attempt to [update matrix](#318) failed because rubocop version is not fixed so `~> 0.65` resolved to version above `0.75`.  I guess it was mistake not to define it as `~> 0.65.0` 

Last version of rubocop passing is `0.74` so fixing that version.
Bumping of rubocop could be addressed in own PR.