### PR TITLE
pass options to delegators when they accept it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * Your contribution here.
 * [#333](https://github.com/ruby-grape/grape-entity/pull/333): Fix typo in CHANGELOG.md - [@eitoball](https://github.com/eitoball).
+* [#336](https://github.com/ruby-grape/grape-entity/pull/336): Pass options to delegators when they accept it - [@dnesteryuk](https://github.com/dnesteryuk).
 
 ### 0.8.0 (2020-02-18)
 

--- a/lib/grape_entity/delegator/fetchable_object.rb
+++ b/lib/grape_entity/delegator/fetchable_object.rb
@@ -4,7 +4,7 @@ module Grape
   class Entity
     module Delegator
       class FetchableObject < Base
-        def delegate(attribute, **)
+        def delegate(attribute)
           object.fetch attribute
         end
       end

--- a/lib/grape_entity/delegator/openstruct_object.rb
+++ b/lib/grape_entity/delegator/openstruct_object.rb
@@ -4,7 +4,7 @@ module Grape
   class Entity
     module Delegator
       class OpenStructObject < Base
-        def delegate(attribute, **)
+        def delegate(attribute)
           object.send attribute
         end
       end

--- a/lib/grape_entity/delegator/plain_object.rb
+++ b/lib/grape_entity/delegator/plain_object.rb
@@ -4,7 +4,7 @@ module Grape
   class Entity
     module Delegator
       class PlainObject < Base
-        def delegate(attribute, **)
+        def delegate(attribute)
           object.send attribute
         end
 


### PR DESCRIPTION
This change reduces hash allocations.

Here is a simplified example what was happening.

```ruby
def do_not_accept_keywords(**)
end

100.times { do_not_accept_keywords(hash: true) }
```

After measuring via memory profiler, we got this:

    Total allocated: 69600 bytes (300 objects)

    allocated memory by location
    -----------------------------------
         69600  profile/sample.rb:15

It points to a line where the method gets called. So, every call created a separate hash. It was happening for `Grape::Entity::Delegator::PlainObject`.

If options get extracted, the picture is better.

```ruby
def do_not_accept_keywords(**)
end

opts = { hash: true }

100.times { do_not_accept_keywords(opts) }
```

Allocation:

    Total allocated: 46632 bytes (201 objects)

    allocated memory by location
    -----------------------------------
         46400  profile/sample.rb:15
           232  profile/sample.rb:13

However, there is no object allocation if nothing is passed to the method.

    Total allocated: 0 bytes (0 objects)

Btw, if a method "swallows" arguments, but nothing is passed, there is still allocation.

```ruby
def do_not_accept_keywords(**)
end

100.times { do_not_accept_keywords }
```

Result:

    Total allocated: 23200 bytes (100 objects)

    allocated memory by location
    -----------------------------------
         23200  profile/sample.rb:15

The splat operator brings its cost.

So, now Grape Entity checks whether the delegetor accepts options before passing them.

I measured this change against our production:

**Before:**

    Total allocated: 1512362 bytes (12328 objects)

    allocated memory by location
    -----------------------------------
        605520  /usr/local/bundle/gems/grape-entity-0.8.0/lib/grape_entity/entity.rb:537 

**After:**

    Total allocated: 908402 bytes (9733 objects)

    allocated memory by location
    -----------------------------------
         18000  /app/grape-entity/lib/grape_entity/entity.rb:553

0.57 MB of RAM were saved while serving the identical request.