### PR TITLE
Fix ruby 2.7 deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### Fixes
 
-* Your contribution here.
+* [#338](https://github.com/ruby-grape/grape-entity/pull/338): Fix ruby 2.7 deprecation warning - [@begotten63](https://github.com/begotten63).
 
 ### 0.8.1 (2020-07-15)
 

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -537,7 +537,7 @@ module Grape
       if is_defined_in_entity?(attribute)
         send(attribute)
       elsif @delegator_accepts_opts
-        delegator.delegate(attribute, self.class.delegation_opts)
+        delegator.delegate(attribute, **self.class.delegation_opts)
       else
         delegator.delegate(attribute)
       end


### PR DESCRIPTION
Fix warning with keyword arguments:

`/Users/begotten63/.rvm/gems/ruby-2.7.1/gems/grape-entity-0.8.1/lib/grape_entity/entity.rb:540: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call`

`/Users/begotten63/.rvm/gems/ruby-2.7.1/gems/grape-entity-0.8.1/lib/grape_entity/delegator/hash_object.rb:7: warning: The called method 'delegate' is defined here`
