### PR TITLE
Adds ruby 3.0.0 to travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,21 @@ after_success:
   - bundle exec danger
 
 rvm:
-  - 2.5.8
   - 2.6.6
   - 2.7.2
-  - ruby-head
-  - jruby-head
-  - truffleruby-head
-  - 2.4.10
-
+  - 3.0.0
 
 matrix:
   fast_finish: true
 
+  include:
+    - rvm: 2.5.8
+    - rvm: ruby-head
+    - rvm: jruby-head
+    - rvm: truffleruby-head
+
   allow_failures:
-    - rvm: 2.4.10
+    - rvm: 2.5.8
     - rvm: ruby-head
     - rvm: jruby-head
     - rvm: truffleruby-head

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 * Your contribution here.
+* [#342](https://github.com/ruby-grape/grape-entity/pull/342): Adds ruby 3.0.0 to travis - [@LeFnord](https://github.com/LeFnord).
 
 #### Fixes
 

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -122,8 +122,6 @@ module Grape
           case value
           when :to_s, :str, :string
             :to_s
-          when :to_sym, :sym, :symbol
-            :to_sym
           else
             :to_sym
           end

--- a/lib/grape_entity/exposure/nesting_exposure/output_builder.rb
+++ b/lib/grape_entity/exposure/nesting_exposure/output_builder.rb
@@ -51,7 +51,6 @@ module Grape
             output
           end
 
-          # rubocop:disable Lint/EmptyBlock
           # In case if we want to solve collisions providing lambda to :merge option
           def merge_strategy(for_merge)
             if for_merge.respond_to? :call
@@ -60,7 +59,6 @@ module Grape
               -> {}
             end
           end
-          # rubocop:enable Lint/EmptyBlock
         end
       end
     end


### PR DESCRIPTION
- removes 2.4.10 tests
- move 2.5.8 to allowed failures -> not official supported anymore