### PR TITLE
Add default value option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Your contribution here.
 
+* [#352](https://github.com/ruby-grape/grape-entity/pull/352): Add Default value option - [@ahmednaguib](https://github.com/ahmednaguib).
+
 #### Fixes
 
 * Your contribution here.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
       - [Aliases](#aliases)
       - [Format Before Exposing](#format-before-exposing)
       - [Expose Nil](#expose-nil)
+      - [Default Value](#default-value)
       - [Documentation](#documentation)
     - [Options Hash](#options-hash)
       - [Passing Additional Option To Nested Exposure](#passing-additional-option-to-nested-exposure)
@@ -478,6 +479,19 @@ module  Entities
       expose :name
       expose :age, expose_nil: true # nil values would be rendered as null in the JSON
     end
+  end
+end
+```
+
+#### Default Value
+
+This option can be used to provide a default value in case the return value is nil or empty.
+
+```ruby
+module  Entities
+  class MyModel < Grape::Entity
+    expose :name, default: ''
+    expose :age, default: 60
   end
 end
 ```

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -585,6 +585,7 @@ module Grape
       merge
       expose_nil
       override
+      default
     ].to_set.freeze
 
     # Merges the given options with current block options.

--- a/lib/grape_entity/exposure/base.rb
+++ b/lib/grape_entity/exposure/base.rb
@@ -16,6 +16,7 @@ module Grape
           key = options[:as] || attribute
           @key = key.respond_to?(:to_sym) ? key.to_sym : key
           @is_safe = options[:safe]
+          @default_value = options[:default]
           @for_merge = options[:merge]
           @attr_path_proc = options[:attr_path]
           @documentation = options[:documentation]
@@ -82,7 +83,10 @@ module Grape
         end
 
         def valid_value(entity, options)
-          value(entity, options) if valid?(entity)
+          return unless valid?(entity)
+
+          output = value(entity, options)
+          output.blank? && @default_value.present? ? @default_value : output
         end
 
         def should_return_key?(options)


### PR DESCRIPTION
### Description
I noticed there is no direct way of defining default value for `expose` when a field is returning `nil`. Of course there is a way to do it via a block but would be a nice option to have it like this:
`expose :x, default: 0`

I also saw there is an issue opened https://github.com/ruby-grape/grape-entity/issues/327 asking for the feature so I made the pr maybe it will be useful for other folks.
