### PR TITLE
:only/:except options for expose

### DIFF
--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -192,10 +192,15 @@ module Grape
       options = merge_options(args.last.is_a?(Hash) ? args.pop : {})
 
       if args.size > 1
-
         raise ArgumentError, 'You may not use the :as option on multi-attribute exposures.' if options[:as]
         raise ArgumentError, 'You may not use the :expose_nil on multi-attribute exposures.' if options.key?(:expose_nil)
+        raise ArgumentError, 'You may not use the :only on multi-attribute exposures.' if options.key?(:only)
+        raise ArgumentError, 'You may not use the :except on multi-attribute exposures.' if options.key?(:except)
         raise ArgumentError, 'You may not use block-setting on multi-attribute exposures.' if block_given?
+      end
+
+      if (options.key?(:only) || options.key?(:except)) && !options.key?(:using)
+        raise ArgumentError, 'You cannot use the :only/:except without :using.'
       end
 
       if block_given?
@@ -585,6 +590,8 @@ module Grape
       merge
       expose_nil
       override
+      only
+      except
     ].to_set.freeze
 
     # Merges the given options with current block options.

--- a/lib/grape_entity/exposure/base.rb
+++ b/lib/grape_entity/exposure/base.rb
@@ -4,7 +4,7 @@ module Grape
   class Entity
     module Exposure
       class Base
-        attr_reader :attribute, :is_safe, :documentation, :override, :conditions, :for_merge
+        attr_reader :attribute, :is_safe, :documentation, :override, :conditions, :for_merge, :only, :except
 
         def self.new(attribute, options, conditions, *args, &block)
           super(attribute, options, conditions).tap { |e| e.setup(*args, &block) }
@@ -20,6 +20,8 @@ module Grape
           @attr_path_proc = options[:attr_path]
           @documentation = options[:documentation]
           @override = options[:override]
+          @only = options[:only]
+          @except = options[:except]
           @conditions = conditions
         end
 

--- a/lib/grape_entity/exposure/represent_exposure.rb
+++ b/lib/grape_entity/exposure/represent_exposure.rb
@@ -23,7 +23,7 @@ module Grape
         end
 
         def value(entity, options)
-          new_options = options.for_nesting(key(entity))
+          new_options = options.for_nesting(key(entity)).with_expose(self)
           using_class.represent(@subexposure.value(entity, options), new_options)
         end
 

--- a/lib/grape_entity/options.rb
+++ b/lib/grape_entity/options.rb
@@ -31,6 +31,19 @@ module Grape
         Options.new(merged)
       end
 
+      def with_expose(expose)
+        opts_only_ary = Array(self[:only])
+        opts_except_ary = Array(self[:except])
+
+        only_ary = Array(expose.only)
+        except_ary = Array(expose.except)
+
+        merge(
+          only: (opts_only_ary.any? || only_ary.any?) ? opts_only_ary | only_ary : nil,
+          except: (opts_except_ary.any? || except_ary.any?) ? opts_except_ary | except_ary : nil
+        )
+      end
+
       def reverse_merge(new_opts)
         return self if new_opts.empty?
 


### PR DESCRIPTION
These options are useful to specify exposed fields per request:

```ruby
class User < GE
  expose :name
  expose :email
end

class Responce1 < GE
  expose :users, using: User, only: :name
end

class Respose2 < GE 
  expose :users, using: User, only: :email
end
```

As the result we have one shared type (`User`) that can be used in different context that need **only** specific fields from that type.