### PR TITLE
Pass the right options when determining whether to expose an attribute using a block

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ AllCops:
     - vendor/**/*
     - example/**/*
   NewCops: enable
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.0
   SuggestExtensions: false
 
 #  Layout stuff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Fixes
 
+* [#381](https://github.com/ruby-grape/grape-entity/pull/381): Fix `expose_nil: false` when using a block - [@magni-](https://github.com/magni-).
 * Your contribution here.
 
 

--- a/lib/grape_entity/condition/base.rb
+++ b/lib/grape_entity/condition/base.rb
@@ -4,8 +4,8 @@ module Grape
   class Entity
     module Condition
       class Base
-        def self.new(inverse, *args, &block)
-          super(inverse).tap { |e| e.setup(*args, &block) }
+        def self.new(inverse, ...)
+          super(inverse).tap { |e| e.setup(...) }
         end
 
         def initialize(inverse = false)

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -598,10 +598,10 @@ module Grape
           if existing_val.is_a?(Hash) && new_val.is_a?(Hash)
             existing_val.merge(new_val)
           elsif new_val.is_a?(Hash)
-            (opts["#{key}_extras".to_sym] ||= []) << existing_val
+            (opts[:"#{key}_extras"] ||= []) << existing_val
             new_val
           else
-            (opts["#{key}_extras".to_sym] ||= []) << new_val
+            (opts[:"#{key}_extras"] ||= []) << new_val
             existing_val
           end
         else

--- a/lib/grape_entity/exposure.rb
+++ b/lib/grape_entity/exposure.rb
@@ -54,7 +54,7 @@ module Grape
 
         def expose_nil_condition(attribute, options)
           Condition.new_unless(
-            proc do |object, _options|
+            proc do |object, entity_options|
               if options[:proc].nil?
                 delegator = Delegator.new(object)
                 if is_a?(Grape::Entity) && delegator.accepts_options?
@@ -63,7 +63,7 @@ module Grape
                   delegator.delegate(attribute).nil?
                 end
               else
-                exec_with_object(options, &options[:proc]).nil?
+                exec_with_object(entity_options, &options[:proc]).nil?
               end
             end
           )

--- a/lib/grape_entity/exposure/base.rb
+++ b/lib/grape_entity/exposure/base.rb
@@ -9,8 +9,8 @@ module Grape
       class Base
         attr_reader :attribute, :is_safe, :documentation, :override, :conditions, :for_merge
 
-        def self.new(attribute, options, conditions, *args, &block)
-          super(attribute, options, conditions).tap { |e| e.setup(*args, &block) }
+        def self.new(attribute, options, conditions, ...)
+          super(attribute, options, conditions).tap { |e| e.setup(...) }
         end
 
         def initialize(attribute, options, conditions)

--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -131,8 +131,8 @@ describe Grape::Entity do
 
           context 'when expose_nil option is false and block passed' do
             it 'does not expose if block returns nil' do
-              subject.expose(:a, expose_nil: false) do |_obj, _options|
-                nil
+              subject.expose(:a, expose_nil: false) do |_obj, options|
+                options[:option_a]
               end
               subject.expose(:b)
               subject.expose(:c)
@@ -140,12 +140,12 @@ describe Grape::Entity do
             end
 
             it 'exposes is block returns a value' do
-              subject.expose(:a, expose_nil: false) do |_obj, _options|
-                100
+              subject.expose(:a, expose_nil: false) do |_obj, options|
+                options[:option_a]
               end
               subject.expose(:b)
               subject.expose(:c)
-              expect(subject.represent(model).serializable_hash).to eq(a: 100, b: nil, c: 'value')
+              expect(subject.represent(model, option_a: 100).serializable_hash).to eq(a: 100, b: nil, c: 'value')
             end
           end
         end

--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -30,9 +30,11 @@ describe Grape::Entity do
 
         it 'makes sure that :format_with as a proc cannot be used with a block' do
           # rubocop:disable Style/BlockDelimiters
-          # rubocop:disable Lint/Debugger
-          expect { subject.expose :name, format_with: proc {} do p 'hi' end }.to raise_error ArgumentError
-          # rubocop:enable Lint/Debugger
+          expect {
+            subject.expose :name, format_with: proc {} do
+              p 'hi'
+            end
+          }.to raise_error ArgumentError
           # rubocop:enable Style/BlockDelimiters
         end
 


### PR DESCRIPTION
As @zverok deduced when [opening the issue](https://github.com/ruby-grape/grape-entity/issues/378#issue-1853710374), the wrong options are getting used when pairing `expose_nil: false` with a block.

Fixes #378 