### PR TITLE
Drop `multijson` dependency

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
+--require spec_helper
 --color
 --profile
 --format documentation

--- a/grape-entity.gemspec
+++ b/grape-entity.gemspec
@@ -17,8 +17,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 3.0'
 
   s.add_runtime_dependency 'activesupport', '>= 3.0.0'
-  # FIXME: remove dependecy
-  s.add_runtime_dependency 'multi_json', '>= 1.3.2'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec}/*`.split("\n")

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'multi_json'
+require 'grape_entity/json'
 
 module Grape
   # An Entity is a lightweight structure that allows you to easily
@@ -558,7 +558,7 @@ module Grape
 
     def to_json(options = {})
       options = options.to_h if options&.respond_to?(:to_h)
-      MultiJson.dump(serializable_hash(options))
+      Grape::Entity::Json.dump(serializable_hash(options))
     end
 
     def to_xml(options = {})

--- a/lib/grape_entity/json.rb
+++ b/lib/grape_entity/json.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Grape
+  class Entity
+    if defined?(::MultiJson)
+      Json = ::MultiJson
+    else
+      Json = ::JSON
+      Json::ParseError = Json::ParserError
+    end
+  end
+end

--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
 require 'ostruct'
 
 describe Grape::Entity do
@@ -1752,6 +1751,16 @@ describe Grape::Entity do
           expect(presenter.serializable_hash(only: %i[a b])).to eq(a: 1, b: 2)
           expect(presenter.serializable_hash(only: %i[b c])).to eq(b: 2, c: 3)
         end
+      end
+    end
+
+    describe '#to_json' do
+      before do
+        fresh_class.expose :name
+      end
+
+      it 'returns a json' do
+        expect(fresh_class.new(model).to_json).to eq(JSON.generate(attributes.slice(:name)))
       end
     end
 

--- a/spec/grape_entity/exposure/nesting_exposure/nested_exposures_spec.rb
+++ b/spec/grape_entity/exposure/nesting_exposure/nested_exposures_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 describe Grape::Entity::Exposure::NestingExposure::NestedExposures do
   subject(:nested_exposures) { described_class.new([]) }
 

--- a/spec/grape_entity/exposure/represent_exposure_spec.rb
+++ b/spec/grape_entity/exposure/represent_exposure_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 describe Grape::Entity::Exposure::RepresentExposure do
   subject(:exposure) { described_class.new(:foo, {}, {}, double, double) }
 

--- a/spec/grape_entity/exposure_spec.rb
+++ b/spec/grape_entity/exposure_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 describe Grape::Entity::Exposure do
   let(:fresh_class) { Class.new(Grape::Entity) }
   let(:model) { double(attributes) }

--- a/spec/grape_entity/hash_spec.rb
+++ b/spec/grape_entity/hash_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 describe Grape::Entity do
   it 'except option for nested entity', :aggregate_failures do
     module EntitySpec

--- a/spec/grape_entity/json_spec.rb
+++ b/spec/grape_entity/json_spec.rb
@@ -3,5 +3,5 @@
 describe Grape::Entity::Json do
   subject { described_class }
 
-  it { is_expected.to eq(::JSON) }
+  it { is_expected.to eq(JSON) }
 end

--- a/spec/grape_entity/json_spec.rb
+++ b/spec/grape_entity/json_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+describe Grape::Entity::Json do
+  subject { described_class }
+
+  it { is_expected.to eq(::JSON) }
+end

--- a/spec/grape_entity/options_spec.rb
+++ b/spec/grape_entity/options_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 describe Grape::Entity::Options do
   module EntitySpec
     class Crystalline


### PR DESCRIPTION
This PR adds a `Grape::Entity::Json` class that will use `multijson` if already loaded instead of the default `json`.

A spec has been added to make sure `to_json` still works and moved `require 'spec_helper'` in `.rspec` file