### PR TITLE
Block arity detection

### DIFF
--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -525,7 +525,8 @@ module Grape
         if arity.positive?
           raise ArgumentError, <<~MSG
             Symbol to proc wrapper blocks must have zero arguments, but got #{arity}.
-            Expose methods with as: or use a block with no parameters.
+            Use a regular block with parameters or access presented instance (`object`)
+            and the top-level entity options (`options`) directly.
           MSG
         end
       else

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -519,7 +519,7 @@ module Grape
     end
 
     def exec_with_object(options, &block)
-      if block.parameters.count == 1
+      if block.parameters.count == 1 || block.parameters == [[:req], [:rest]]
         instance_exec(object, &block)
       else
         instance_exec(object, options, &block)
@@ -528,6 +528,7 @@ module Grape
       # it handles: https://github.com/ruby/ruby/blob/v3_0_0_preview1/NEWS.md#language-changes point 3, Proc
       # accounting for expose :foo, &:bar
       if e.is_a?(ArgumentError) && block.parameters == [[:req], [:rest]]
+        Rails.logger.error("***** ERROR in exec_with_object: #{e.message}\n#{e.backtrace.join("\n")}")
         raise Grape::Entity::Deprecated.new e.message, 'in ruby 3.0'
       end
 

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -518,21 +518,26 @@ module Grape
       root_exposure.serializable_value(self, opts)
     end
 
+    def determine_block_arity(block)
+      # As from Ruby 3.0, the block parameters are always equal to `[[:req], [:rest]]`
+      # In that case the method name could be extracted from the block to find the original method arity.
+      origin_method_name = block.to_s.scan(/(?<=\(&:)[^)]+(?=\))/).first&.to_sym
+
+      if origin_method_name && object.respond_to?(origin_method_name, true)
+        object.method(origin_method_name).parameters.size
+      else
+        block.parameters.size
+      end
+    end
+
     def exec_with_object(options, &block)
-      if block.parameters.count == 1 || block.parameters == [[:req], [:rest]]
+      block_arity = determine_block_arity(block)
+
+      if block_arity == 0
         instance_exec(object, &block)
       else
         instance_exec(object, options, &block)
       end
-    rescue StandardError => e
-      # it handles: https://github.com/ruby/ruby/blob/v3_0_0_preview1/NEWS.md#language-changes point 3, Proc
-      # accounting for expose :foo, &:bar
-      if e.is_a?(ArgumentError) && block.parameters == [[:req], [:rest]]
-        Rails.logger.error("***** ERROR in exec_with_object: #{e.message}\n#{e.backtrace.join("\n")}")
-        raise Grape::Entity::Deprecated.new e.message, 'in ruby 3.0'
-      end
-
-      raise e
     end
 
     def exec_with_attribute(attribute, &block)

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -533,7 +533,7 @@ module Grape
     def exec_with_object(options, &block)
       block_arity = determine_block_arity(block)
 
-      if block_arity == 0
+      if block_arity.zero?
         instance_exec(object, &block)
       else
         instance_exec(object, options, &block)

--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -423,28 +423,16 @@ describe Grape::Entity do
           end
 
           context 'with block passed in via &' do
-            if RUBY_VERSION.start_with?('3')
-              specify do
-                subject.expose :that_method_without_args, &:method_without_args
-                subject.expose :method_without_args, as: :that_method_without_args_again
+            specify do
+              subject.expose :that_method_without_args, &:method_without_args
+              subject.expose :method_without_args, as: :that_method_without_args_again
 
-                object = SomeObject.new
-                expect do
-                  subject.represent(object).value_for(:that_method_without_args)
-                end.to raise_error Grape::Entity::Deprecated
+              object = SomeObject.new
+              value1 = subject.represent(object).value_for(:that_method_without_args)
+              expect(value1).to eq('result')
 
-                value2 = subject.represent(object).value_for(:that_method_without_args_again)
-                expect(value2).to eq('result')
-              end
-            else
-              specify do
-                subject.expose :that_method_without_args_again, &:method_without_args
-
-                object = SomeObject.new
-
-                value2 = subject.represent(object).value_for(:that_method_without_args_again)
-                expect(value2).to eq('result')
-              end
+              value2 = subject.represent(object).value_for(:that_method_without_args_again)
+              expect(value2).to eq('result')
             end
           end
         end

--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -436,8 +436,13 @@ describe Grape::Entity do
               subject.expose :method_without_args, as: :that_method_without_args_again
 
               object = SomeObject.new
+
+              value = subject.represent(object).value_for(:method_without_args)
+              expect(value).to be_nil
+
               value = subject.represent(object).value_for(:that_method_without_args)
               expect(value).to eq('result')
+
               value = subject.represent(object).value_for(:that_method_without_args_again)
               expect(value).to eq('result')
             end
@@ -452,10 +457,23 @@ describe Grape::Entity do
 
               expect do
                 subject.represent(object).value_for(:that_method_with_one_arg)
-              end.to raise_error ArgumentError, match(/blocks must have zero arguments/)
+              end.to raise_error ArgumentError, match(/method expects 1 argument/)
+
               expect do
                 subject.represent(object).value_for(:that_method_with_multple_args)
-              end.to raise_error ArgumentError, match(/blocks must have zero arguments/)
+              end.to raise_error ArgumentError, match(/method expects 2 arguments/)
+            end
+          end
+
+          context 'with symbol-to-proc passed in via &' do
+            specify do
+              subject.expose :that_undefined_method, &:unknown_method
+
+              object = SomeObject.new
+
+              expect do
+                subject.represent(object).value_for(:that_undefined_method)
+              end.to raise_error ArgumentError, match(/method is not defined in the object/)
             end
           end
         end

--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -393,6 +393,14 @@ describe Grape::Entity do
               'result'
             end
 
+            def method_with_one_arg(_object)
+              'result'
+            end
+
+            def method_with_multiple_args(_object, _options)
+              'result'
+            end
+
             def raises_argument_error
               raise ArgumentError, 'something different'
             end
@@ -428,11 +436,26 @@ describe Grape::Entity do
               subject.expose :method_without_args, as: :that_method_without_args_again
 
               object = SomeObject.new
-              value1 = subject.represent(object).value_for(:that_method_without_args)
-              expect(value1).to eq('result')
+              value = subject.represent(object).value_for(:that_method_without_args)
+              expect(value).to eq('result')
+              value = subject.represent(object).value_for(:that_method_without_args_again)
+              expect(value).to eq('result')
+            end
+          end
 
-              value2 = subject.represent(object).value_for(:that_method_without_args_again)
-              expect(value2).to eq('result')
+          context 'with block passed in via &' do
+            specify do
+              subject.expose :that_method_with_one_arg, &:method_with_one_arg
+              subject.expose :that_method_with_multple_args, &:method_with_multiple_args
+
+              object = SomeObject.new
+
+              expect do
+                subject.represent(object).value_for(:that_method_with_one_arg)
+              end.to raise_error ArgumentError, match(/blocks must have zero arguments/)
+              expect do
+                subject.represent(object).value_for(:that_method_with_multple_args)
+              end.to raise_error ArgumentError, match(/blocks must have zero arguments/)
             end
           end
         end


### PR DESCRIPTION
Ruby 3’s stricter Proc arity rules could slip unwanted arguments into &:method_name exposures, causing confusing errors. This change detects pure symbol-to-proc wrappers up front, looks up the actual method’s arity on the entity object, and raises an error if it’s not zero. Regular blocks still use their own arity to decide whether to pass options. In practice, this makes it impossible to accidentally expose a one- or two-argument method with &:foo, ensuring only truly zero-argument methods are used in that shorthand.

Possible sollution #376