### PR TITLE
Release 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,21 @@
 ### Next
 
-#### Features
-
-* Your contribution here.
+### 1.0.2 (2026-04-13)
 
 #### Fixes
 
 * [#394](https://github.com/ruby-grape/grape-entity/pull/394): Add `Entity.[]` for Grape >= 3.2 param type compatibility - [@numbata](https://github.com/numbata).
 * [#388](https://github.com/ruby-grape/grape-entity/pull/388): Drop ruby-head from test matrix - [@numbata](https://github.com/numbata).
 * [#384](https://github.com/ruby-grape/grape-entity/pull/384): Fix `inspect` to correctly handle `nil` values - [@fcce](https://github.com/fcce).
-* Your contribution here.
 
-### ### 1.0.1 (2024-04-10)
+### 1.0.1 (2024-04-10)
 
 #### Fixes
 
 * [#381](https://github.com/ruby-grape/grape-entity/pull/381): Fix `expose_nil: false` when using a block - [@magni-](https://github.com/magni-).
 
 
-### ### 1.0.0 (2023-02-16)
+### 1.0.0 (2023-02-16)
 
 #### Fixes
 

--- a/lib/grape_entity/version.rb
+++ b/lib/grape_entity/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GrapeEntity
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'
 end


### PR DESCRIPTION
## Summary

Release 1.0.2 brings compatibility improvements and bug fixes:

- **Grape 3.2 compatibility** — Entities now work seamlessly as parameter types in Grape 3.2+, removing the need for workarounds when using entities for coercion.
- **Fixed `inspect` for nil values** — Inspecting entities with `nil` attribute values no longer raises errors, improving debuggability.
- **CI maintenance** — Dropped `ruby-head` from the test matrix to keep builds stable and green.