### PR TITLE
Prepare for next development cycle, 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ### Next
 
+#### Features
+
+* Your contribution here.
+
+#### Fixes
+
+* Your contribution here.
+
 ### 1.0.2 (2026-04-13)
 
 #### Fixes

--- a/lib/grape_entity/version.rb
+++ b/lib/grape_entity/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GrapeEntity
-  VERSION = '1.0.2'
+  VERSION = '1.0.3'
 end


### PR DESCRIPTION
## Summary

- Bump version to 1.0.3 for the next development cycle.
- Add placeholder sections to CHANGELOG for upcoming contributions.