### PR TITLE
Reduce gem size by excluding test files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 * [#400](https://github.com/ruby-grape/grape-entity/pull/400): Switch to danger-pr-comment for PR checks - [@numbata](https://github.com/numbata).
+* [#397](https://github.com/ruby-grape/grape-entity/pull/397): Reduce gem size by excluding test files - [@yuri-zubov](https://github.com/yuri-zubov).
 * Your contribution here.
 
 #### Fixes

--- a/grape-entity.gemspec
+++ b/grape-entity.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activesupport', '>= 3.0.0'
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec}/*`.split("\n")
+  s.files         = `git ls-files lib`.split("\n") + ['CHANGELOG.md', 'LICENSE', 'README.md']
   s.require_paths = ['lib']
 end


### PR DESCRIPTION
This pull request updates the *.gemspec file to optimize the gem package size and structure

```bash
$ gem build -o before.tar

$ git switch reduce-gem-size

$ gem build -o after.tar

$ du -sh before.tar after.tar
 48K	before.tar
 28K	after.tar
 ```
 
| Metric | Before | After | Saved                 |
|--------|--------|-------|-----------------------|
| Size   | 48K   | 28K   | −20K (⏷ −41.7%)      |


###  whitch files was deleted?

```diff
data
-├── .github
-│   ├── workflows
-│   │   └── ci.yml
-│   └── dependabot.yml
-├── bench
-│   └── serializing.rb
 ├── lib
 │   ├── grape_entity
 │   │   ├── condition
 │   │   │   ├── base.rb
 │   │   │   ├── block_condition.rb
 │   │   │   ├── hash_condition.rb
 │   │   │   └── symbol_condition.rb
 │   │   ├── delegator
 │   │   │   ├── base.rb
 │   │   │   ├── hash_object.rb
 │   │   │   ├── openstruct_object.rb
 │   │   │   └── plain_object.rb
 │   │   ├── exposure
 │   │   │   ├── nesting_exposure
 │   │   │   │   ├── nested_exposures.rb
 │   │   │   │   └── output_builder.rb
 │   │   │   ├── base.rb
 │   │   │   ├── block_exposure.rb
 │   │   │   ├── delegator_exposure.rb
 │   │   │   ├── formatter_block_exposure.rb
 │   │   │   ├── formatter_exposure.rb
 │   │   │   ├── nesting_exposure.rb
 │   │   │   └── represent_exposure.rb
 │   │   ├── condition.rb
 │   │   ├── delegator.rb
 │   │   ├── deprecated.rb
 │   │   ├── entity.rb
 │   │   ├── exposure.rb
 │   │   ├── json.rb
 │   │   ├── options.rb
 │   │   └── version.rb
 │   ├── grape_entity.rb
 │   └── grape-entity.rb
-├── spec
-│   ├── grape_entity
-│   │   ├── exposure
-│   │   │   ├── nesting_exposure
-│   │   │   │   └── nested_exposures_spec.rb
-│   │   │   └── represent_exposure_spec.rb
-│   │   ├── entity_spec.rb
-│   │   ├── exposure_spec.rb
-│   │   ├── hash_spec.rb
-│   │   ├── json_spec.rb
-│   │   └── options_spec.rb
-│   └── spec_helper.rb
-├── .coveralls.yml
-├── .gitignore
-├── .rspec
-├── .rubocop_todo.yml
-├── .rubocop.yml
-├── .yardopts
 ├── CHANGELOG.md
-├── CONTRIBUTING.md
-├── Dangerfile
-├── Gemfile
-├── grape-entity.gemspec
-├── Guardfile
 ├── LICENSE
-├── Rakefile
 ├── README.md
-├── RELEASING.md
-└── UPGRADING.md
```

ps: you can see on [rails repo](https://github.com/rails/rails/blob/main/actioncable/actioncable.gemspec#L20)