### PR TITLE
Update CHANGELOG with missing entries for version 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
 * [#394](https://github.com/ruby-grape/grape-entity/pull/394): Add `Entity.[]` for Grape >= 3.2 param type compatibility - [@numbata](https://github.com/numbata).
 * [#388](https://github.com/ruby-grape/grape-entity/pull/388): Drop ruby-head from test matrix - [@numbata](https://github.com/numbata).
 * [#384](https://github.com/ruby-grape/grape-entity/pull/384): Fix `inspect` to correctly handle `nil` values - [@fcce](https://github.com/fcce).
+* [#385](https://github.com/ruby-grape/grape-entity/pull/385): Drop multijson dependency - [ericproulx](https://github.com/ericproulx).
+
+
+**Breaking change:**
+* [#389](https://github.com/ruby-grape/grape-entity/pull/389): Block arity detection - [@numbata](https://github.com/numbata).
+
 
 ### 1.0.1 (2024-04-10)
 


### PR DESCRIPTION
Added entries for missing PRs within the version. Especially for a breaking change that is failing 400+ tests for us.