### PR TITLE
Add Danger CI checks for pull requests

### DIFF
--- a/.github/workflows/danger-comment.yml
+++ b/.github/workflows/danger-comment.yml
@@ -1,0 +1,11 @@
+name: Danger Comment
+
+on:
+  workflow_run:
+    workflows: [Danger]
+    types: [completed]
+
+jobs:
+  comment:
+    uses: numbata/danger-pr-comment/.github/workflows/danger-comment.yml@v0.1.0
+    secrets: inherit

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,0 +1,13 @@
+name: Danger
+
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+
+jobs:
+  danger:
+    uses: numbata/danger-pr-comment/.github/workflows/danger-run.yml@v0.1.0
+    secrets: inherit
+    with:
+      ruby-version: '3.4'
+      bundler-cache: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Features
 
+* [#400](https://github.com/ruby-grape/grape-entity/pull/400): Switch to danger-pr-comment for PR checks - [@numbata](https://github.com/numbata).
 * Your contribution here.
 
 #### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,7 @@
 
 #### Fixes
 
-**Breaking change:**
-* [#352](https://github.com/ruby-grape/grape-entity/pull/369): Remove `FetchableObject` behavior. - [@danielvdao](https://github.com/danielvdao).
+* [#352](https://github.com/ruby-grape/grape-entity/pull/369): **Breaking change:** Remove `FetchableObject` behavior - [@danielvdao](https://github.com/danielvdao).
 * [#371](https://github.com/ruby-grape/grape-entity/pull/371): Allow default exposed value to be `false` or any empty data - [@norydev](https://github.com/norydev).
 
 
@@ -38,7 +37,7 @@
 
 #### Fixes
 
-* [#366](https://github.com/ruby-grape/grape-entity/pull/366): Don't suppress regular ArgumentError exceptions - [splattael](https://github.com/splattael).
+* [#366](https://github.com/ruby-grape/grape-entity/pull/366): Don't suppress regular ArgumentError exceptions - [@splattael](https://github.com/splattael).
 * [#363](https://github.com/ruby-grape/grape-entity/pull/338): Fix typo - [@OuYangJinTing](https://github.com/OuYangJinTing).
 * [#361](https://github.com/ruby-grape/grape-entity/pull/361): Require 'active_support/core_ext' - [@pravi](https://github.com/pravi).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 * [#394](https://github.com/ruby-grape/grape-entity/pull/394): Add `Entity.[]` for Grape >= 3.2 param type compatibility - [@numbata](https://github.com/numbata).
 * [#388](https://github.com/ruby-grape/grape-entity/pull/388): Drop ruby-head from test matrix - [@numbata](https://github.com/numbata).
+* [#389](https://github.com/ruby-grape/grape-entity/pull/389): **Breaking change:** Block arity detection - [@numbata](https://github.com/numbata).
+* [#385](https://github.com/ruby-grape/grape-entity/pull/385): Drop multijson dependency - [@ericproulx](https://github.com/ericproulx).
 * [#384](https://github.com/ruby-grape/grape-entity/pull/384): Fix `inspect` to correctly handle `nil` values - [@fcce](https://github.com/fcce).
 
 ### 1.0.1 (2024-04-10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 * [#394](https://github.com/ruby-grape/grape-entity/pull/394): Add `Entity.[]` for Grape >= 3.2 param type compatibility - [@numbata](https://github.com/numbata).
 * [#388](https://github.com/ruby-grape/grape-entity/pull/388): Drop ruby-head from test matrix - [@numbata](https://github.com/numbata).
-* [#389](https://github.com/ruby-grape/grape-entity/pull/389): **Breaking change:** Block arity detection - [@numbata](https://github.com/numbata).
+* [#389](https://github.com/ruby-grape/grape-entity/pull/389): Block arity detection (breaking change) - [@numbata](https://github.com/numbata).
 * [#385](https://github.com/ruby-grape/grape-entity/pull/385): Drop multijson dependency - [@ericproulx](https://github.com/ericproulx).
 * [#384](https://github.com/ruby-grape/grape-entity/pull/384): Fix `inspect` to correctly handle `nil` values - [@fcce](https://github.com/fcce).
 
@@ -31,7 +31,7 @@
 
 #### Fixes
 
-* [#352](https://github.com/ruby-grape/grape-entity/pull/369): **Breaking change:** Remove `FetchableObject` behavior - [@danielvdao](https://github.com/danielvdao).
+* [#369](https://github.com/ruby-grape/grape-entity/pull/369): Remove `FetchableObject` behavior (breaking change) - [@danielvdao](https://github.com/danielvdao).
 * [#371](https://github.com/ruby-grape/grape-entity/pull/371): Allow default exposed value to be `false` or any empty data - [@norydev](https://github.com/norydev).
 
 
@@ -40,7 +40,7 @@
 #### Fixes
 
 * [#366](https://github.com/ruby-grape/grape-entity/pull/366): Don't suppress regular ArgumentError exceptions - [@splattael](https://github.com/splattael).
-* [#363](https://github.com/ruby-grape/grape-entity/pull/338): Fix typo - [@OuYangJinTing](https://github.com/OuYangJinTing).
+* [#363](https://github.com/ruby-grape/grape-entity/pull/363): Fix typo - [@OuYangJinTing](https://github.com/OuYangJinTing).
 * [#361](https://github.com/ruby-grape/grape-entity/pull/361): Require 'active_support/core_ext' - [@pravi](https://github.com/pravi).
 
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
-danger.import_dangerfile(gem: 'ruby-grape-danger')
+danger.import_dangerfile(gem: 'danger-pr-comment')
+
+changelog.check!

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,8 @@ group :test do
   gem 'guard-bundler'
   gem 'guard-rspec'
   gem 'rb-fsevent'
-  gem 'ruby-grape-danger', '~> 0.2', require: false
+  gem 'danger', require: false
+  gem 'danger-changelog', require: false
+  gem 'danger-pr-comment', require: false
   gem 'simplecov', require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -18,13 +18,13 @@ end
 
 group :test do
   gem 'coveralls_reborn', require: false
+  gem 'danger', require: false
+  gem 'danger-changelog', require: false
+  gem 'danger-pr-comment', require: false
   gem 'growl'
   gem 'guard'
   gem 'guard-bundler'
   gem 'guard-rspec'
   gem 'rb-fsevent'
-  gem 'danger', require: false
-  gem 'danger-changelog', require: false
-  gem 'danger-pr-comment', require: false
   gem 'simplecov', require: false
 end


### PR DESCRIPTION
## Summary

Automate pull request quality checks by adding [Danger](https://danger.systems) to the CI pipeline. This ensures every PR follows project conventions — such as including a CHANGELOG entry — before it can be merged, reducing manual review burden and keeping the project consistent.

- Switch from `ruby-grape-danger` to [`danger-pr-comment`](https://github.com/numbata/danger-pr-comment), aligning with how [grape](https://github.com/ruby-grape/grape) handles PR checks
- Danger results are posted as PR comments so contributors get clear, actionable feedback
- Fix several historical CHANGELOG formatting issues caught by the new checks