### PR TITLE
Modernize gemspec: add metadata, use Dir glob, drop defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#400](https://github.com/ruby-grape/grape-entity/pull/400): Switch to danger-pr-comment for PR checks - [@numbata](https://github.com/numbata).
 * [#397](https://github.com/ruby-grape/grape-entity/pull/397): Reduce gem size by excluding test files - [@yuri-zubov](https://github.com/yuri-zubov).
+* [#401](https://github.com/ruby-grape/grape-entity/pull/401): Modernize gemspec: add metadata, use Dir glob, require MFA - [@numbata](https://github.com/numbata).
 * Your contribution here.
 
 #### Fixes

--- a/grape-entity.gemspec
+++ b/grape-entity.gemspec
@@ -6,7 +6,6 @@ require 'grape_entity/version'
 Gem::Specification.new do |s|
   s.name        = 'grape-entity'
   s.version     = GrapeEntity::VERSION
-  s.platform    = Gem::Platform::RUBY
   s.authors     = ['LeFnord', 'Michael Bleigh']
   s.email       = ['pscholz.le@gmail.com', 'michael@intridea.com']
   s.homepage    = 'https://github.com/ruby-grape/grape-entity'
@@ -14,10 +13,19 @@ Gem::Specification.new do |s|
   s.description = 'Extracted from Grape, A Ruby framework for rapid API development with great conventions.'
   s.license     = 'MIT'
 
+  s.metadata = {
+    'homepage_uri' => 'https://github.com/ruby-grape/grape-entity',
+    'bug_tracker_uri' => 'https://github.com/ruby-grape/grape-entity/issues',
+    'changelog_uri' => "https://github.com/ruby-grape/grape-entity/blob/v#{s.version}/CHANGELOG.md",
+    'documentation_uri' => "https://www.rubydoc.info/gems/grape-entity/#{s.version}",
+    'source_code_uri' => "https://github.com/ruby-grape/grape-entity/tree/v#{s.version}",
+    'rubygems_mfa_required' => 'true'
+  }
+
   s.required_ruby_version = '>= 3.0'
 
   s.add_dependency 'activesupport', '>= 3.0.0'
 
-  s.files         = `git ls-files lib`.split("\n") + ['CHANGELOG.md', 'LICENSE', 'README.md']
+  s.files         = Dir['lib/**/*.rb', 'CHANGELOG.md', 'LICENSE', 'README.md']
   s.require_paths = ['lib']
 end


### PR DESCRIPTION
## Summary

- Replace `git ls-files` shell-out with `Dir['lib/**/*.rb', ...]` to avoid
  dependency on git at build time and prevent accidental inclusion of
  non-Ruby files or directories
- Add RubyGems metadata (homepage, bug tracker, changelog, docs, source code)
  and require MFA for gem pushes via `rubygems_mfa_required`
- Remove redundant `s.platform = Gem::Platform::RUBY` (it is the default)