### PR TITLE
Remove `Json::ParseError` assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 #### Fixes
 
 * Your contribution here.
-
+* [#402](https://github.com/ruby-grape/grape-entity/pull/402): Remove `Json::ParseError` assignment - [@olivier-thatch](https://github.com/olivier-thatch).
 
 ### 1.0.3 (2026-04-15)
 

--- a/lib/grape_entity/json.rb
+++ b/lib/grape_entity/json.rb
@@ -2,11 +2,6 @@
 
 module Grape
   class Entity
-    if defined?(::MultiJson)
-      Json = ::MultiJson
-    else
-      Json = ::JSON
-      Json::ParseError = Json::ParserError
-    end
+    Json = defined?(::MultiJson) ? ::MultiJson : ::JSON
   end
 end


### PR DESCRIPTION
#385 was merged and released in grape-entity 1.0.2 (cf. [changelog](https://github.com/ruby-grape/grape-entity/blob/master/CHANGELOG.md#102-2026-04-13)).

However, the main grape gem also defines `ParseError`, which produces ugly warnings:
```
/Users/olivier/.rbenv/versions/4.0.2/lib/ruby/gems/4.0.0/gems/grape-entity-1.0.3/lib/grape_entity/json.rb:9: warning: already initialized constant JSON::ParseError
/Users/olivier/.rbenv/versions/4.0.2/lib/ruby/gems/4.0.0/gems/grape-3.2.0/lib/grape/json.rb:8: warning: previous definition of ParseError was here
/Users/olivier/.rbenv/versions/4.0.2/lib/ruby/gems/4.0.0/gems/grape-entity-1.0.3/lib/grape_entity/json.rb:9: warning: already initialized constant JSON::ParseError
/Users/olivier/.rbenv/versions/4.0.2/lib/ruby/gems/4.0.0/gems/grape-3.2.0/lib/grape/json.rb:8: warning: previous definition of ParseError was here
```

Since grape-entity makes no use of `ParseError` (cf. https://github.com/ruby-grape/grape-entity/pull/385/changes#r1594479678), we can drop the assignment entirely.
