### PR TITLE
Fix Time serialization regression from dropping MultiJson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#404](https://github.com/ruby-grape/grape-entity/pull/404): Drop `MultiJson` dependency, use `Hash#to_json` for ActiveSupport-aware serialization - [@numbata](https://github.com/numbata).
 
 ### 1.0.4 (2026-04-17)
 

--- a/grape-entity.gemspec
+++ b/grape-entity.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 3.0'
 
   s.add_dependency 'activesupport', '>= 3.0.0'
-  s.add_dependency 'multi_json', '>= 1.0'
 
   s.files         = Dir['lib/**/*.rb', 'CHANGELOG.md', 'LICENSE', 'README.md']
   s.require_paths = ['lib']

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'multi_json'
-
 module Grape
   # An Entity is a lightweight structure that allows you to easily
   # represent data from your application in a consistent and abstracted
@@ -594,7 +592,13 @@ module Grape
 
     def to_json(options = {})
       options = options.to_h if options&.respond_to?(:to_h)
+<<<<<<< HEAD
       MultiJson.dump(serializable_hash(options))
+||||||| parent of 374a021 (Fix Time serialization regression introduced by dropping MultiJson)
+      Grape::Entity::Json.dump(serializable_hash(options))
+=======
+      serializable_hash(options).to_json
+>>>>>>> 374a021 (Fix Time serialization regression introduced by dropping MultiJson)
     end
 
     def to_xml(options = {})

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -592,13 +592,7 @@ module Grape
 
     def to_json(options = {})
       options = options.to_h if options&.respond_to?(:to_h)
-<<<<<<< HEAD
-      MultiJson.dump(serializable_hash(options))
-||||||| parent of 374a021 (Fix Time serialization regression introduced by dropping MultiJson)
-      Grape::Entity::Json.dump(serializable_hash(options))
-=======
       serializable_hash(options).to_json
->>>>>>> 374a021 (Fix Time serialization regression introduced by dropping MultiJson)
     end
 
     def to_xml(options = {})

--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -1886,7 +1886,7 @@ describe Grape::Entity do
         entity = fresh_class.new(model)
         json = entity.to_json
         parsed = JSON.parse(json)
-        expect(parsed['birthday']).to eq(attributes[:birthday].as_json)
+        expect(parsed['birthday']).to eq('2012-02-27T00:00:00.000Z')
       end
 
       it 'serializes Time values in nested exposures via as_json' do
@@ -1895,7 +1895,7 @@ describe Grape::Entity do
         end
         entity = fresh_class.new(model)
         parsed = JSON.parse(entity.to_json)
-        expect(parsed['details']['birthday']).to eq(attributes[:birthday].as_json)
+        expect(parsed['details']['birthday']).to eq('2012-02-27T00:00:00.000Z')
       end
     end
 


### PR DESCRIPTION
## Summary

Version 1.0.3 introduced a silent breaking change for all API consumers: `Time` fields switched from ISO 8601 format (`"2026-04-16T10:55:10.597Z"`) to Ruby's default `Time#to_s` format (`"2026-04-16 10:55:10 UTC"`). This breaks any client parsing timestamps from the API.

## What happened

PR #385 replaced `MultiJson.dump` with `JSON.dump` in `Entity#to_json` to drop the `multi_json` dependency. While the intent was correct, `JSON.dump` and `MultiJson.dump` behave differently when ActiveSupport is present:

- **`MultiJson.dump(hash)`** internally calls `Hash#to_json`, which ActiveSupport overrides to run `as_json` recursively on all values — giving `Time` the ISO 8601 representation.
- **`JSON.dump(hash)`** goes directly to Ruby's C extension JSON generator, bypassing ActiveSupport's `Hash#to_json` override entirely — so `Time` falls back to `Time#to_s`.

Since ActiveSupport is a runtime dependency of grape-entity, every user is affected.

An additional problem noted by @stevenou: the intermediate `Grape::Entity::Json` constant used `defined?(::MultiJson)` at require time to decide which backend to use. For apps with `gem "multi_json", require: false`, MultiJson wasn't loaded yet at that point, so it always fell back to `::JSON` regardless — making the MultiJson detection dead code in practice.

## How this fix works

Replaces `Grape::Entity::Json.dump(serializable_hash(options))` with `serializable_hash(options).to_json`.

`Hash#to_json` is the method ActiveSupport overrides. This single change resolves all reported problems:

1. **Time serialization** — `Hash#to_json` goes through ActiveSupport's `as_json` chain, restoring ISO 8601 output for `Time` and any other type with an `as_json` override.
2. **Nested exposures** — `OutputBuilder` (a `SimpleDelegator` wrapping a Hash) properly delegates `.to_json` to the underlying Hash.
3. **MultiJson load-order race** — eliminated entirely. We no longer check for or use MultiJson at all, so `require: false` scenarios are irrelevant.

The now-unused `Grape::Entity::Json` constant and `grape_entity/json.rb` are removed.

Fixes #403