### PR TITLE
Revert dropping MultiJson to fix Time serialization regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#405](https://github.com/ruby-grape/grape-entity/pull/405): Fix `Time` serialization regression by reverting #385 and restoring `MultiJson.dump` - [@numbata](https://github.com/numbata).
 * [#402](https://github.com/ruby-grape/grape-entity/pull/402): Remove `Json::ParseError` assignment - [@olivier-thatch](https://github.com/olivier-thatch).
 
 ### 1.0.3 (2026-04-15)

--- a/grape-entity.gemspec
+++ b/grape-entity.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 3.0'
 
   s.add_dependency 'activesupport', '>= 3.0.0'
+  s.add_dependency 'multi_json', '>= 1.0'
 
   s.files         = Dir['lib/**/*.rb', 'CHANGELOG.md', 'LICENSE', 'README.md']
   s.require_paths = ['lib']

--- a/lib/grape_entity/entity.rb
+++ b/lib/grape_entity/entity.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'grape_entity/json'
+require 'multi_json'
 
 module Grape
   # An Entity is a lightweight structure that allows you to easily
@@ -594,7 +594,7 @@ module Grape
 
     def to_json(options = {})
       options = options.to_h if options&.respond_to?(:to_h)
-      Grape::Entity::Json.dump(serializable_hash(options))
+      MultiJson.dump(serializable_hash(options))
     end
 
     def to_xml(options = {})

--- a/lib/grape_entity/json.rb
+++ b/lib/grape_entity/json.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module Grape
-  class Entity
-    Json = defined?(::MultiJson) ? ::MultiJson : ::JSON
-  end
-end

--- a/spec/grape_entity/entity_spec.rb
+++ b/spec/grape_entity/entity_spec.rb
@@ -1880,6 +1880,23 @@ describe Grape::Entity do
       it 'returns a json' do
         expect(fresh_class.new(model).to_json).to eq(JSON.generate(attributes.slice(:name)))
       end
+
+      it 'serializes Time values via as_json' do
+        fresh_class.expose :birthday
+        entity = fresh_class.new(model)
+        json = entity.to_json
+        parsed = JSON.parse(json)
+        expect(parsed['birthday']).to eq(attributes[:birthday].as_json)
+      end
+
+      it 'serializes Time values in nested exposures via as_json' do
+        fresh_class.expose :details do
+          fresh_class.expose :birthday
+        end
+        entity = fresh_class.new(model)
+        parsed = JSON.parse(entity.to_json)
+        expect(parsed['details']['birthday']).to eq(attributes[:birthday].as_json)
+      end
     end
 
     describe '#inspect' do

--- a/spec/grape_entity/json_spec.rb
+++ b/spec/grape_entity/json_spec.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-describe Grape::Entity::Json do
-  subject { described_class }
-
-  it { is_expected.to eq(JSON) }
-end


### PR DESCRIPTION
## Summary

This reverts the behavioral changes from #385 ("Drop multijson dependency") which introduced a silent breaking change in 1.0.3: all `Time` fields in API responses changed format for applications using ActiveSupport.

- **Before (1.0.1):** `"2026-04-16T10:55:10.597Z"` (ISO 8601)
- **After (1.0.3):** `"2026-04-16 10:55:10 UTC"`

The goal is to restore the exact serialization behavior from 1.0.1 for a patch release, so affected consumers can upgrade immediately without changes on their side.

## What went wrong

PR #385 replaced `MultiJson.dump` with `JSON.dump` (via a `Grape::Entity::Json` shim) in `Entity#to_json`. These two methods behave differently when ActiveSupport is loaded:

- **`MultiJson.dump(hash)`** internally calls `Hash#to_json`, which ActiveSupport overrides to run `as_json` recursively — giving `Time` its ISO 8601 representation.
- **`JSON.dump(hash)`** goes directly to Ruby's C extension JSON generator, bypassing ActiveSupport's override — so `Time` falls back to `Time#to_s`.

Since `activesupport` is a runtime dependency of grape-entity, every user was affected.

Additionally, the `Grape::Entity::Json` shim from #385 checked `defined?(::MultiJson)` at require time to decide which backend to use. For applications with `gem "multi_json", require: false`, MultiJson was never loaded at that point — so the constant always resolved to `::JSON`, making the MultiJson detection dead code in practice (as noted by @stevenou in #403).

## What this PR does

- Restores `require 'multi_json'` and `MultiJson.dump` in `Entity#to_json` — the same code path that was in place at 1.0.1
- Re-adds `multi_json` as a gemspec dependency
- Removes the `Grape::Entity::Json` shim (`lib/grape_entity/json.rb`) and its spec, as they are no longer referenced
- Adds regression tests that assert `Time` values serialize via `as_json` in both flat and nested exposures

A separate PR (#404) explores dropping MultiJson entirely without the regression by using `Hash#to_json` directly — that is a candidate for a future minor release.

Fixes #403